### PR TITLE
Increase GCP default node type

### DIFF
--- a/infra/gcp/cc-cluster-gke-std-csr-cs/nodepool.yaml
+++ b/infra/gcp/cc-cluster-gke-std-csr-cs/nodepool.yaml
@@ -8,7 +8,9 @@ metadata:
 spec:
   location: example # kpt-set: ${location}
   autoscaling:
-    minNodeCount: 4
-    maxNodeCount: 10
+    totalMinNodeCount: 4
+    totalMaxNodeCount: 10
   clusterRef:
     name: example # kpt-set: ${name}
+  nodeConfig:
+    machineType: e2-standard-4


### PR DESCRIPTION
The default machine type for nodes was too small to run some of our components in the management cluster, so this modifies the node pool to use 4 CPU machines.

This applies only to the GCP opinionated install.