### PR TITLE
Remove annotation that fixes gitea address

### DIFF
--- a/distros/sandbox/gitea/service-gitea.yaml
+++ b/distros/sandbox/gitea/service-gitea.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: gitea
   annotations:
-    metallb.universe.tf/loadBalancerIPs: 172.18.0.200
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
What type of PR is this?

    Uncomment only one  /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

    /kind cleanup
    /kind design
    /kind documentation
    /kind failing-test
    /kind feature
    /kind flake

What this PR does / why we need it:
The current gitea package will not install if the installation environment does not use an address range with the address  172.18.0.200 in it. This PR removes the annotation that insists on a fixed IP address for the Gitea service.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?: