### PR TITLE
Add metallb-sandbox-config package

### DIFF
--- a/distros/sandbox/metallb-sandbox-config/Kptfile
+++ b/distros/sandbox/metallb-sandbox-config/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: metallb-sandbox-config
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: Nephio Sandbox config for Metal LB

--- a/distros/sandbox/metallb-sandbox-config/README.md
+++ b/distros/sandbox/metallb-sandbox-config/README.md
@@ -1,0 +1,21 @@
+# metallb-sandbox-config
+
+## Description
+Nephio Sandbox config for Metal LB
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] metallb-sandbox-config`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree metallb-sandbox-config`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init metallb-sandbox-config
+kpt live apply metallb-sandbox-config --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/distros/sandbox/metallb-sandbox-config/ipaddresspool.yaml
+++ b/distros/sandbox/metallb-sandbox-config/ipaddresspool.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: nephio
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.18.0.0/20

--- a/distros/sandbox/metallb-sandbox-config/l2advertisement.yaml
+++ b/distros/sandbox/metallb-sandbox-config/l2advertisement.yaml
@@ -1,0 +1,5 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: nephio
+  namespace: metallb-system

--- a/distros/sandbox/metallb-sandbox-config/package-context.yaml
+++ b/distros/sandbox/metallb-sandbox-config/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example


### PR DESCRIPTION
This package is used by the Sandbox installation to define some IP range used by MetalLB services.