### PR TITLE
Update porch-controllers Deployment

### DIFF
--- a/nephio/core/porch/9-controllers.yaml
+++ b/nephio/core/porch/9-controllers.yaml
@@ -36,13 +36,14 @@ spec:
     spec:
       serviceAccountName: porch-controllers
       containers:
-      - name: porch-controllers
-        # Update to the image of your porch-controllers build.
-        image: docker.io/nephio/porch-controllers:latest
-        # Note: only the existence of the variable matters for enabling the reconciler
-        # So, be sure to remove the var not just change the value to false
-        env:
-        - name: ENABLE_PACKAGEVARIANTSETS
-          value: "true"
-        - name: ENABLE_PACKAGEVARIANTS
-          value: "true"
+        - name: porch-controllers
+          # Update to the image of your porch-controllers build.
+          image: docker.io/nephio/porch-controllers:latest
+          imagePullPolicy: IfNotPresent
+          # Note: only the existence of the variable matters for enabling the reconciler
+          # So, be sure to remove the var not just change the value to false
+          env:
+            - name: ENABLE_PACKAGEVARIANTSETS
+              value: "true"
+            - name: ENABLE_PACKAGEVARIANTS
+              value: "true"


### PR DESCRIPTION
Update ImagePullPolicy to IfNotPresent for porch-controllers. (The Always policy causes the run-in-kind make target to fail)
Fix yaml indentation.