### PR TITLE
Drop unnecessary SMF nfdeploy-fn call

### DIFF
--- a/workloads/free5gc/pkg-example-smf-bp/Kptfile
+++ b/workloads/free5gc/pkg-example-smf-bp/Kptfile
@@ -20,4 +20,3 @@ pipeline:
     - image: docker.io/nephio/nad-fn:latest
     - image: docker.io/nephio/dnn-fn:latest
     - image: docker.io/nephio/interface-fn:latest
-    - image: docker.io/nephio/nfdeploy-fn:1745600386007306240


### PR DESCRIPTION
The SMF configuration file is generated based on the [UPF list value provided](https://github.com/nephio-project/free5gc/blob/main/controllers/nf/smf/templates.go#L80). This value seems to be altered by the second call of the `nfdeploy-fn` call. This change proposes to remove it to avoid misconfiguration and PDU session establishment in free5gc calls.