### PR TITLE
Use `latest` Docker tags

### DIFF
--- a/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-token-controller.yaml
+++ b/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-token-controller.yaml
@@ -76,7 +76,7 @@ spec:
           value: gitea
         - name: ENABLE_TOKENS
           value: "true"
-        image: docker.io/nephio/nephio-operator:v1.0.1
+        image: docker.io/nephio/nephio-operator:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/distros/gcp/nephio-mgmt/nephio-webui/Kptfile
+++ b/distros/gcp/nephio-mgmt/nephio-webui/Kptfile
@@ -27,5 +27,5 @@ pipeline:
       configPath: apply-replacements.yaml
     - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: set-auth.yaml
-    - image: docker.io/nephio/gen-configmap-fn:2023-09-14-01
+    - image: docker.io/nephio/gen-configmap-fn:latest
       configPath: gen-configmap.yaml

--- a/distros/gcp/nephio-mgmt/network-config/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/network-config/app/controller/deployment-controller.yaml
@@ -74,7 +74,7 @@ spec:
           value: "true"
         - name: ENABLE_NETWORKCONFIGS
           value: "true"
-        image: docker.io/nephio/network-config-operator:v1.0.1
+        image: docker.io/nephio/network-config-operator:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/distros/gcp/nephio-mgmt/resource-backend/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/resource-backend/app/controller/deployment-controller.yaml
@@ -86,7 +86,7 @@ spec:
           value: "true"
         - name: ENABLE_RAWTOPOLOGIES
           value: "true"
-        image: docker.io/nephio/resource-backend-controller:v1.0.1
+        image: docker.io/nephio/resource-backend-controller:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/nephio/optional/webui/Kptfile
+++ b/nephio/optional/webui/Kptfile
@@ -11,5 +11,5 @@ pipeline:
   mutators:
   - image: gcr.io/kpt-fn/starlark:v0.5.0
     configPath: set-auth.yaml
-  - image: docker.io/nephio/gen-configmap-fn:2023-09-14-01
+  - image: docker.io/nephio/gen-configmap-fn:latest
     configPath: gen-configmap.yaml

--- a/workloads/free5gc/pkg-example-amf-bp/Kptfile
+++ b/workloads/free5gc/pkg-example-amf-bp/Kptfile
@@ -14,10 +14,10 @@ pipeline:
       configPath: apply-replacements-namespace.yaml
     - image: gcr.io/kpt-fn/set-namespace:v0.4.1
       configPath: cm-namespace.yaml
-    - image: docker.io/nephio/nfdeploy-fn:1745600386007306240
+    - image: docker.io/nephio/nfdeploy-fn:latest
     - image: docker.io/nephio/interface-fn:latest
     - image: docker.io/nephio/dnn-fn:latest
     - image: docker.io/nephio/nad-fn:latest
     - image: docker.io/nephio/dnn-fn:latest
     - image: docker.io/nephio/interface-fn:latest
-    - image: docker.io/nephio/nfdeploy-fn:1745600386007306240
+    - image: docker.io/nephio/nfdeploy-fn:latest

--- a/workloads/free5gc/pkg-example-smf-bp/Kptfile
+++ b/workloads/free5gc/pkg-example-smf-bp/Kptfile
@@ -14,7 +14,7 @@ pipeline:
       configPath: apply-replacements-namespace.yaml
     - image: gcr.io/kpt-fn/set-namespace:v0.4.1
       configPath: cm-namespace.yaml
-    - image: docker.io/nephio/nfdeploy-fn:1745600386007306240
+    - image: docker.io/nephio/nfdeploy-fn:latest
     - image: docker.io/nephio/interface-fn:latest
     - image: docker.io/nephio/dnn-fn:latest
     - image: docker.io/nephio/nad-fn:latest

--- a/workloads/free5gc/pkg-example-upf-bp/Kptfile
+++ b/workloads/free5gc/pkg-example-upf-bp/Kptfile
@@ -14,10 +14,10 @@ pipeline:
       configPath: apply-replacements-namespace.yaml
     - image: gcr.io/kpt-fn/set-namespace:v0.4.1
       configPath: package-context.yaml
-    - image: docker.io/nephio/nfdeploy-fn:1745600386007306240
+    - image: docker.io/nephio/nfdeploy-fn:latest
     - image: docker.io/nephio/interface-fn:latest
     - image: docker.io/nephio/dnn-fn:latest
     - image: docker.io/nephio/nad-fn:latest
     - image: docker.io/nephio/dnn-fn:latest
     - image: docker.io/nephio/interface-fn:latest
-    - image: docker.io/nephio/nfdeploy-fn:1745600386007306240
+    - image: docker.io/nephio/nfdeploy-fn:latest

--- a/workloads/oai/pkg-example-cucp-bp/Kptfile
+++ b/workloads/oai/pkg-example-cucp-bp/Kptfile
@@ -15,8 +15,8 @@ pipeline:
     configPath: apply-replacements-namespace.yaml
   - image: gcr.io/kpt-fn/set-namespace:v0.4.1
     configPath: package-context.yaml
-  - image: nephio/nfdeploy-fn:1729579664202010624
-  - image: docker.io/nephio/interface-fn:v1.0.1
-  - image: docker.io/nephio/nad-fn:v1.0.1
-  - image: docker.io/nephio/interface-fn:v1.0.1
-  - image: nephio/nfdeploy-fn:1729579664202010624
+  - image: nephio/nfdeploy-fn:latest
+  - image: docker.io/nephio/interface-fn:latest
+  - image: docker.io/nephio/nad-fn:latest
+  - image: docker.io/nephio/interface-fn:latest
+  - image: nephio/nfdeploy-fn:latest

--- a/workloads/oai/pkg-example-cuup-bp/Kptfile
+++ b/workloads/oai/pkg-example-cuup-bp/Kptfile
@@ -15,8 +15,8 @@ pipeline:
     configPath: apply-replacements-namespace.yaml
   - image: gcr.io/kpt-fn/set-namespace:v0.4.1
     configPath: package-context.yaml
-  - image: nephio/nfdeploy-fn:1729579664202010624
-  - image: docker.io/nephio/interface-fn:v1.0.1
-  - image: docker.io/nephio/nad-fn:v1.0.1
-  - image: docker.io/nephio/interface-fn:v1.0.1
-  - image: nephio/nfdeploy-fn:1729579664202010624
+  - image: nephio/nfdeploy-fn:latest
+  - image: docker.io/nephio/interface-fn:latest
+  - image: docker.io/nephio/nad-fn:latest
+  - image: docker.io/nephio/interface-fn:latest
+  - image: nephio/nfdeploy-fn:latest

--- a/workloads/oai/pkg-example-du-bp/Kptfile
+++ b/workloads/oai/pkg-example-du-bp/Kptfile
@@ -15,8 +15,8 @@ pipeline:
     configPath: apply-replacements-namespace.yaml
   - image: gcr.io/kpt-fn/set-namespace:v0.4.1
     configPath: package-context.yaml
-  - image: nephio/nfdeploy-fn:1729579664202010624
-  - image: docker.io/nephio/interface-fn:v1.0.1
-  - image: docker.io/nephio/nad-fn:v1.0.1
-  - image: docker.io/nephio/interface-fn:v1.0.1
-  - image: nephio/nfdeploy-fn:1729579664202010624
+  - image: nephio/nfdeploy-fn:latest
+  - image: docker.io/nephio/interface-fn:latest
+  - image: docker.io/nephio/nad-fn:latest
+  - image: docker.io/nephio/interface-fn:latest
+  - image: nephio/nfdeploy-fn:latest

--- a/workloads/tools/ueransim/Kptfile
+++ b/workloads/tools/ueransim/Kptfile
@@ -14,8 +14,8 @@ pipeline:
       configPath: apply-replacements-namespace.yaml
     - image: gcr.io/kpt-fn/set-namespace:v0.4.1
       configPath: package-context.yaml
-    - image: docker.io/nephio/ueransim-deploy-fn:v1.0.1
-    - image: docker.io/nephio/interface-fn:v1.0.1
-    - image: docker.io/nephio/nad-fn:v1.0.1
-    - image: docker.io/nephio/interface-fn:v1.0.1
-    - image: docker.io/nephio/ueransim-deploy-fn:v1.0.1
+    - image: docker.io/nephio/ueransim-deploy-fn:latest
+    - image: docker.io/nephio/interface-fn:latest
+    - image: docker.io/nephio/nad-fn:latest
+    - image: docker.io/nephio/interface-fn:latest
+    - image: docker.io/nephio/ueransim-deploy-fn:latest


### PR DESCRIPTION
This PR modifies the Docker tags of all the kpt packages to point to the latest version available