### PR TITLE
Reversing the v2.0.0 to main for stock repo

### DIFF
--- a/infra/gcp/nephio-blueprint-repo/pv-repo.yaml
+++ b/infra/gcp/nephio-blueprint-repo/pv-repo.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: cc-repo-csr
     repo: blueprints-infra-gcp
-    revision: main
+    revision: v2.0.0
   downstream:
     package: example
     repo: config-control

--- a/infra/gcp/nephio-workload-cluster-gke/pv-cluster.yaml
+++ b/infra/gcp/nephio-workload-cluster-gke/pv-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: cc-cluster-gke-std-csr-cs
     repo: blueprints-infra-gcp
-    revision: main
+    revision: v2.0.0
   downstream:
     package: example
     repo: config-control

--- a/nephio/optional/stock-repos/repo-distros-sandbox-packages.yaml
+++ b/nephio/optional/stock-repos/repo-distros-sandbox-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /distros/sandbox
     repo: https://github.com/nephio-project/catalog.git
   type: git

--- a/nephio/optional/stock-repos/repo-free5gc-packages.yaml
+++ b/nephio/optional/stock-repos/repo-free5gc-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /workloads/free5gc
     repo: https://github.com/nephio-project/catalog.git
   type: git

--- a/nephio/optional/stock-repos/repo-infra-capi-packages.yaml
+++ b/nephio/optional/stock-repos/repo-infra-capi-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /infra/capi
     repo: https://github.com/nephio-project/catalog.git
   type: git

--- a/nephio/optional/stock-repos/repo-nephio-core-packages.yaml
+++ b/nephio/optional/stock-repos/repo-nephio-core-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /nephio/core
     repo: https://github.com/nephio-project/catalog.git
   type: git

--- a/nephio/optional/stock-repos/repo-nephio-example-packages.yaml
+++ b/nephio/optional/stock-repos/repo-nephio-example-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /
     repo: https://github.com/nephio-project/nephio-example-packages.git
   type: git

--- a/nephio/optional/stock-repos/repo-nephio-optional-packages.yaml
+++ b/nephio/optional/stock-repos/repo-nephio-optional-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /nephio/optional
     repo: https://github.com/nephio-project/catalog.git
   type: git

--- a/nephio/optional/stock-repos/repo-oai-core-packages.yaml
+++ b/nephio/optional/stock-repos/repo-oai-core-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /
     repo: https://github.com/OPENAIRINTERFACE/oai-packages.git
   type: git

--- a/nephio/optional/stock-repos/repo-oai-packages.yaml
+++ b/nephio/optional/stock-repos/repo-oai-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /workloads/oai
     repo: https://github.com/nephio-project/catalog.git
   type: git

--- a/nephio/optional/stock-repos/repo-oai-ran-packages.yaml
+++ b/nephio/optional/stock-repos/repo-oai-ran-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v2.0.0
+    branch: main
     directory: /workloads/oai
     repo: https://github.com/nephio-project/catalog.git
   type: git


### PR DESCRIPTION
The stock repo can use `main` as branch rather than tag `v2.0.0`