### PR TITLE
#588 - Add missing repository rbac roles for porch controllers

### DIFF
--- a/nephio/core/porch/9-porch-controller-packagevariants-clusterrole.yaml
+++ b/nephio/core/porch/9-porch-controller-packagevariants-clusterrole.yaml
@@ -31,6 +31,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - porch.kpt.dev
   resources:
   - packagerevisionresources

--- a/nephio/core/porch/9-porch-controller-packagevariantsets-clusterrole.yaml
+++ b/nephio/core/porch/9-porch-controller-packagevariantsets-clusterrole.yaml
@@ -48,3 +48,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This change adds missing repository rbac roles for the porch controllers.

Context -
The use cases are working, but after someone creates a PVS or PV and points to a repo, the controller logs are populated with errors saying the controllers cannot 'get' the repositories because k8s sets a watch.