### PR TITLE
Allow configuration of an external webhook and its associated certs in the Porch API server

### DIFF
--- a/nephio/optional/porch-cert-manager-webhook/0-packagerevs.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/0-packagerevs.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: packagerevs.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: PackageRev
+    listKind: PackageRevList
+    plural: packagerevs
+    singular: packagerev
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PackageRev
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageRevSpec defines the desired state of PackageRev
+            type: object
+          status:
+            description: PackageRevStatus defines the observed state of PackageRev
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/optional/porch-cert-manager-webhook/0-packagevariants.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/0-packagevariants.yaml
@@ -1,0 +1,318 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: packagevariants.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: PackageVariant
+    listKind: PackageVariantList
+    plural: packagevariants
+    singular: packagevariant
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PackageVariant represents an upstream and downstream porch package pair. The upstream package should already exist. The PackageVariant controller is responsible for creating the downstream package revisions based on the spec.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageVariantSpec defines the desired state of PackageVariant
+            properties:
+              adoptionPolicy:
+                type: string
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              deletionPolicy:
+                type: string
+              downstream:
+                properties:
+                  package:
+                    type: string
+                  repo:
+                    type: string
+                type: object
+              injectors:
+                items:
+                  description: InjectionSelector specifies how to select in-cluster objects for resolving injection points.
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              packageContext:
+                description: PackageContext defines the data to be added or removed from the kptfile.kpt.dev ConfigMap during reconciliation.
+                properties:
+                  data:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  removeKeys:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              pipeline:
+                description: Pipeline declares a pipeline of functions used to mutate or validate resources.
+                properties:
+                  mutators:
+                    description: Mutators defines a list of of KRM functions that mutate resources.
+                    items:
+                      description: Function specifies a KRM function.
+                      properties:
+                        configMap:
+                          additionalProperties:
+                            type: string
+                          description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                          type: object
+                        configPath:
+                          description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                          type: string
+                        exclude:
+                          description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                        exec:
+                          description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                          type: string
+                        image:
+                          description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                          type: string
+                        name:
+                          description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                          type: string
+                        selectors:
+                          description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  validators:
+                    description: Validators defines a list of KRM functions that validate resources. Validators are not permitted to mutate resources.
+                    items:
+                      description: Function specifies a KRM function.
+                      properties:
+                        configMap:
+                          additionalProperties:
+                            type: string
+                          description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                          type: object
+                        configPath:
+                          description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                          type: string
+                        exclude:
+                          description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                        exec:
+                          description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                          type: string
+                        image:
+                          description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                          type: string
+                        name:
+                          description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                          type: string
+                        selectors:
+                          description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              upstream:
+                properties:
+                  package:
+                    type: string
+                  repo:
+                    type: string
+                  revision:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PackageVariantStatus defines the observed state of PackageVariant
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              downstreamTargets:
+                description: DownstreamTargets contains the downstream targets that the PackageVariant either created or adopted.
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/optional/porch-cert-manager-webhook/0-packagevariantsets.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/0-packagevariantsets.yaml
@@ -1,0 +1,719 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: packagevariantsets.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: PackageVariantSet
+    listKind: PackageVariantSetList
+    plural: packagevariantsets
+    singular: packagevariantset
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PackageVariantSet represents an upstream package revision and a way to target specific downstream repositories where a variant of the upstream package should be created.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageVariantSetSpec defines the desired state of PackageVariantSet
+            properties:
+              adoptionPolicy:
+                type: string
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              deletionPolicy:
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              targets:
+                items:
+                  properties:
+                    objects:
+                      description: 'option 3: a selector against a set of arbitrary objects'
+                      properties:
+                        repoName:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        selectors:
+                          items:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labelSelector:
+                                description: Labels on the target resources
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    package:
+                      description: 'option 1: an explicit repo/package name pair'
+                      properties:
+                        name:
+                          type: string
+                        repo:
+                          type: string
+                      type: object
+                    packageName:
+                      description: For options 2 and 3, PackageName specifies how to create the name of the package variant
+                      properties:
+                        baseName:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        namePrefix:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        nameSuffix:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                      type: object
+                    repositories:
+                      description: 'option 2: a label selector against a set of repositories'
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              upstream:
+                properties:
+                  package:
+                    properties:
+                      name:
+                        type: string
+                      repo:
+                        type: string
+                    type: object
+                  ref:
+                    type: string
+                  revision:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PackageVariantSetStatus defines the observed state of PackageVariantSet
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PackageVariantSet represents an upstream package revision and a way to target specific downstream repositories where a variant of the upstream package should be created.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageVariantSetSpec defines the desired state of PackageVariantSet
+            properties:
+              targets:
+                items:
+                  properties:
+                    objectSelector:
+                      description: 'option 3: a selector against a set of arbitrary objects'
+                      properties:
+                        apiVersion:
+                          description: APIVersion of the target resources
+                          type: string
+                        kind:
+                          description: Kind of the target resources
+                          type: string
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                        name:
+                          description: Name of the target resource
+                          type: string
+                      type: object
+                    repositories:
+                      description: 'Exactly one of Repositories, RepositorySeletor, and ObjectSelector must be populated option 1: an explicit repositories and package names'
+                      items:
+                        properties:
+                          name:
+                            description: Name contains the name of the Repository resource, which must be in the same namespace as the PackageVariantSet resource.
+                            type: string
+                          packageNames:
+                            description: PackageNames contains names to use for package instances in this repository; that is, the same upstream will be instantiated multiple times using these names.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    repositorySelector:
+                      description: 'option 2: a label selector against a set of repositories'
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    template:
+                      description: Template specifies how to generate a PackageVariant from a target
+                      properties:
+                        adoptionPolicy:
+                          description: AdoptionPolicy allows overriding the PackageVariant adoption policy
+                          type: string
+                        annotationExprs:
+                          description: AnnotationsExprs allows specifying the spec.Annotations field of the generated PackageVariant using CEL to dynamically create the keys and values. Entries in this field take precedent over those with the same keys that are present in Annotations.
+                          items:
+                            description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                            properties:
+                              key:
+                                type: string
+                              keyExpr:
+                                type: string
+                              value:
+                                type: string
+                              valueExpr:
+                                type: string
+                            type: object
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations allows specifying the spec.Annotations field of the generated PackageVariant
+                          type: object
+                        deletionPolicy:
+                          description: DeletionPolicy allows overriding the PackageVariant deletion policy
+                          type: string
+                        downstream:
+                          description: Downstream allows overriding the default downstream package and repository name
+                          properties:
+                            package:
+                              type: string
+                            packageExpr:
+                              type: string
+                            repo:
+                              type: string
+                            repoExpr:
+                              type: string
+                          type: object
+                        injectors:
+                          description: Injectors allows specifying the spec.Injectors field of the generated PackageVariant
+                          items:
+                            description: InjectionSelectorTemplate is used to calculate the injectors field of the resulting package variants. Exactly one of the Name and NameExpr fields must be specified. The other fields are optional.
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              nameExpr:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        labelExprs:
+                          description: LabelsExprs allows specifying the spec.Labels field of the generated PackageVariant using CEL to dynamically create the keys and values. Entries in this field take precedent over those with the same keys that are present in Labels.
+                          items:
+                            description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                            properties:
+                              key:
+                                type: string
+                              keyExpr:
+                                type: string
+                              value:
+                                type: string
+                              valueExpr:
+                                type: string
+                            type: object
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels allows specifying the spec.Labels field of the generated PackageVariant
+                          type: object
+                        packageContext:
+                          description: PackageContext allows specifying the spec.PackageContext field of the generated PackageVariant
+                          properties:
+                            data:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            dataExprs:
+                              items:
+                                description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                                properties:
+                                  key:
+                                    type: string
+                                  keyExpr:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueExpr:
+                                    type: string
+                                type: object
+                              type: array
+                            removeKeyExprs:
+                              items:
+                                type: string
+                              type: array
+                            removeKeys:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        pipeline:
+                          description: Pipeline allows specifying the spec.Pipeline field of the generated PackageVariant
+                          properties:
+                            mutators:
+                              description: Mutators is used to caculate the pipeline.mutators field of the resulting package variants.
+                              items:
+                                description: FunctionTemplate is used in generating KRM function pipeline entries; that is, it is used to generate Kptfile Function objects.
+                                properties:
+                                  configMap:
+                                    additionalProperties:
+                                      type: string
+                                    description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                                    type: object
+                                  configMapExprs:
+                                    description: ConfigMapExprs allows use of CEL to dynamically create the keys and values in the function config ConfigMap. Entries in this field take precedent over those with the same keys that are present in ConfigMap.
+                                    items:
+                                      description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                                      properties:
+                                        key:
+                                          type: string
+                                        keyExpr:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  configPath:
+                                    description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                                    type: string
+                                  exclude:
+                                    description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                  exec:
+                                    description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                                    type: string
+                                  image:
+                                    description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                                    type: string
+                                  name:
+                                    description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                                    type: string
+                                  selectors:
+                                    description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            validators:
+                              description: Validators is used to caculate the pipeline.validators field of the resulting package variants.
+                              items:
+                                description: FunctionTemplate is used in generating KRM function pipeline entries; that is, it is used to generate Kptfile Function objects.
+                                properties:
+                                  configMap:
+                                    additionalProperties:
+                                      type: string
+                                    description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                                    type: object
+                                  configMapExprs:
+                                    description: ConfigMapExprs allows use of CEL to dynamically create the keys and values in the function config ConfigMap. Entries in this field take precedent over those with the same keys that are present in ConfigMap.
+                                    items:
+                                      description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                                      properties:
+                                        key:
+                                          type: string
+                                        keyExpr:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  configPath:
+                                    description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                                    type: string
+                                  exclude:
+                                    description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                  exec:
+                                    description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                                    type: string
+                                  image:
+                                    description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                                    type: string
+                                  name:
+                                    description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                                    type: string
+                                  selectors:
+                                    description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              upstream:
+                properties:
+                  package:
+                    type: string
+                  repo:
+                    type: string
+                  revision:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PackageVariantSetStatus defines the observed state of PackageVariantSet
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/optional/porch-cert-manager-webhook/0-repositories.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/0-repositories.yaml
@@ -1,0 +1,266 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: repositories.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: Repository
+    listKind: RepositoryList
+    plural: repositories
+    singular: repository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.content
+      name: Content
+      type: string
+    - jsonPath: .spec.deployment
+      name: Deployment
+      type: boolean
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec['git','oci']['repo','registry']
+      name: Address
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Repository
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "RepositorySpec defines the desired state of Repository \n Notes: - deployment repository - in KRM API ConfigSync would be configured directly? (or via this API)"
+            properties:
+              content:
+                description: 'Content stored in the repository (i.e. Function, Package - the literal values correspond to the API resource names). TODO: support repository with mixed content?'
+                type: string
+              deployment:
+                description: The repository is a deployment repository; final packages in this repository are deployment ready.
+                type: boolean
+              description:
+                description: User-friendly description of the repository
+                type: string
+              git:
+                description: Git repository details. Required if `type` is `git`. Ignored if `type` is not `git`.
+                properties:
+                  branch:
+                    description: Name of the branch containing the packages. Finalized packages will be committed to this branch (if the repository allows write access). If unspecified, defaults to "main".
+                    type: string
+                  createBranch:
+                    description: CreateBranch specifies if Porch should create the package branch if it doesn't exist.
+                    type: boolean
+                  directory:
+                    description: Directory within the Git repository where the packages are stored. A subdirectory of this directory containing a Kptfile is considered a package. If unspecified, defaults to root directory.
+                    type: string
+                  repo:
+                    description: 'Address of the Git repository, for example: `https://github.com/GoogleCloudPlatform/blueprints.git`'
+                    type: string
+                  secretRef:
+                    description: Reference to secret containing authentication credentials.
+                    properties:
+                      name:
+                        description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - repo
+                type: object
+              mutators:
+                description: '`Mutators` specifies list of functions to be added to the list of package''s mutators on changes to the packages in the repository to ensure the packages meet constraints enforced by the mutators associated with the repository. Based on the Kubernetest Admission Controllers (https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). The functions will be evaluated in the order specified in the list.'
+                items:
+                  properties:
+                    configMap:
+                      additionalProperties:
+                        type: string
+                      description: '`ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/).'
+                      type: object
+                    functionRef:
+                      description: '`FunctionRef` specifies the function by reference to a Function resource. Mutually exclusive with `Image`.'
+                      properties:
+                        name:
+                          description: '`Name` is the name of the `Function` resource referenced. The resource is expected to be within the same namespace.'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    image:
+                      description: '`Image` specifies the function image, such as `gcr.io/kpt-fn/gatekeeper:v0.2`. Use of `Image` is mutually exclusive with `FunctionRef`.'
+                      type: string
+                  type: object
+                type: array
+              oci:
+                description: OCI repository details. Required if `type` is `oci`. Ignored if `type` is not `oci`.
+                properties:
+                  registry:
+                    description: Registry is the address of the OCI registry
+                    type: string
+                  secretRef:
+                    description: Reference to secret containing authentication credentials.
+                    properties:
+                      name:
+                        description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - registry
+                type: object
+              type:
+                description: Type of the repository (i.e. git, OCI)
+                type: string
+              upstream:
+                description: Upstream is the default upstream repository for packages in this repository. Specifying it per repository allows simpler UX when creating packages.
+                properties:
+                  git:
+                    description: Git repository details. Required if `type` is `git`. Must be unspecified if `type` is not `git`.
+                    properties:
+                      branch:
+                        description: Name of the branch containing the packages. Finalized packages will be committed to this branch (if the repository allows write access). If unspecified, defaults to "main".
+                        type: string
+                      createBranch:
+                        description: CreateBranch specifies if Porch should create the package branch if it doesn't exist.
+                        type: boolean
+                      directory:
+                        description: Directory within the Git repository where the packages are stored. A subdirectory of this directory containing a Kptfile is considered a package. If unspecified, defaults to root directory.
+                        type: string
+                      repo:
+                        description: 'Address of the Git repository, for example: `https://github.com/GoogleCloudPlatform/blueprints.git`'
+                        type: string
+                      secretRef:
+                        description: Reference to secret containing authentication credentials.
+                        properties:
+                          name:
+                            description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - repo
+                    type: object
+                  oci:
+                    description: OCI repository details. Required if `type` is `oci`. Must be unspecified if `type` is not `oci`.
+                    properties:
+                      registry:
+                        description: Registry is the address of the OCI registry
+                        type: string
+                      secretRef:
+                        description: Reference to secret containing authentication credentials.
+                        properties:
+                          name:
+                            description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - registry
+                    type: object
+                  repositoryRef:
+                    description: RepositoryRef contains a reference to an existing Repository resource to be used as the default upstream repository.
+                    properties:
+                      name:
+                        description: Name of the Repository resource referenced.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: Type of the repository (i.e. git, OCI). If empty, repositoryRef will be used.
+                    type: string
+                type: object
+              validators:
+                description: '`Validators` specifies list of functions to be added to the list of package''s validators on changes to the packages in the repository to ensure the packages meet constraints enforced by the validators associated with the repository. Based on the Kubernetest Admission Controllers (https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). The functions will be evaluated in the order specified in the list.'
+                items:
+                  properties:
+                    configMap:
+                      additionalProperties:
+                        type: string
+                      description: '`ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/).'
+                      type: object
+                    functionRef:
+                      description: '`FunctionRef` specifies the function by reference to a Function resource. Mutually exclusive with `Image`.'
+                      properties:
+                        name:
+                          description: '`Name` is the name of the `Function` resource referenced. The resource is expected to be within the same namespace.'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    image:
+                      description: '`Image` specifies the function image, such as `gcr.io/kpt-fn/gatekeeper:v0.2`. Use of `Image` is mutually exclusive with `FunctionRef`.'
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio/optional/porch-cert-manager-webhook/1-namespace.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/1-namespace.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: porch-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: porch-fn-system

--- a/nephio/optional/porch-cert-manager-webhook/2-2-issuer-cert.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/2-2-issuer-cert.yaml
@@ -1,0 +1,26 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: porch-system-server-certificate
+  namespace: porch-system
+spec:
+  isCA: true
+  commonName: my-selfsigned-ca
+  secretName: porch-system-server-tls
+  duration: 8760h #365d
+  renewBefore: 8640h #360d
+  issuerRef:
+    name: my-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+  dnsNames:
+  - api.porch-system.svc
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: my-ca-issuer
+  namespace: porch-system
+spec:
+  selfSigned: {}

--- a/nephio/optional/porch-cert-manager-webhook/2-3-validating-webhook.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/2-3-validating-webhook.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: packagerev-deletion-validating-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: porch-system/porch-system-server-certificate
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: api
+      namespace: porch-system
+      path: /validate-deletion
+      port: 8443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: packagerevdeletion.google.com
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - porch.kpt.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - DELETE
+    resources:
+    - packagerevisions
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10

--- a/nephio/optional/porch-cert-manager-webhook/2-function-runner.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/2-function-runner.yaml
@@ -1,0 +1,107 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: porch-fn-runner
+  namespace: porch-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: function-runner
+  namespace: porch-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: function-runner
+  template:
+    metadata:
+      labels:
+        app: function-runner
+    spec:
+      serviceAccountName: porch-fn-runner
+      containers:
+        - name: function-runner
+          image: docker.io/nephio/porch-function-runner:v2.0.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /server
+            - --config=/config.yaml
+            - --functions=/functions
+            - --pod-namespace=porch-fn-system
+          env:
+            - name: WRAPPER_SERVER_IMAGE
+              value: docker.io/nephio/porch-wrapper-server:v2.0.0
+          ports:
+            - containerPort: 9445
+          # Add grpc readiness probe to ensure the cache is ready
+          readinessProbe:
+            exec:
+              command:
+                - /grpc-health-probe
+                - -addr
+                - localhost:9445
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 125m
+          volumeMounts:
+            - mountPath: /pod-cache-config
+              name: pod-cache-config-volume
+      volumes:
+        - name: pod-cache-config-volume
+          configMap:
+            name: pod-cache-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: function-runner
+  namespace: porch-system
+spec:
+  selector:
+    app: function-runner
+  ports:
+    - port: 9445
+      protocol: TCP
+      targetPort: 9445
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-cache-config
+  namespace: porch-system
+data:
+  pod-cache-config.yaml: |
+    gcr.io/kpt-fn/apply-replacements:v0.1.1: 30m
+    gcr.io/kpt-fn/apply-setters:v0.2.0: 30m
+    gcr.io/kpt-fn/create-setters:v0.1.0: 30m
+    gcr.io/kpt-fn/ensure-name-substring:v0.2.0: 30m
+    gcr.io/kpt-fn/gatekeeper:v0.2.1: 30m
+    gcr.io/kpt-fn/kubeval:v0.2.0: 30m
+    gcr.io/kpt-fn/search-replace:v0.2.0: 30m
+    gcr.io/kpt-fn/set-annotations:v0.1.4: 30m
+    gcr.io/kpt-fn/set-enforcement-action:v0.1.0: 30m
+    gcr.io/kpt-fn/set-image:v0.1.1: 30m
+    gcr.io/kpt-fn/set-labels:v0.1.5: 30m
+    gcr.io/kpt-fn/set-namespace:v0.4.1: 30m
+    gcr.io/kpt-fn/starlark:v0.4.3: 30m
+    gcr.io/kpt-fn/upsert-resource:v0.2.0: 30m
+    gcr.io/kpt-fn/enable-gcp-services:v0.1.0: 30m
+    gcr.io/kpt-fn/export-terraform:v0.1.0: 30m
+    gcr.io/kpt-fn/generate-folders:v0.1.1: 30m
+    gcr.io/kpt-fn/remove-local-config-resources:v0.1.0: 30m
+    gcr.io/kpt-fn/set-project-id:v0.2.0: 30m

--- a/nephio/optional/porch-cert-manager-webhook/3-porch-server.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/3-porch-server.yaml
@@ -1,0 +1,94 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: porch-server
+  namespace: porch-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: porch-server
+  namespace: porch-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: porch-server
+  template:
+    metadata:
+      labels:
+        app: porch-server
+    spec:
+      serviceAccountName: porch-server
+      volumes:
+        - name: cache-volume
+          emptyDir: {}
+        - name: webhook-certs
+          secret:
+            secretName: porch-system-server-tls
+        - name: api-server-certs
+          emptyDir: {}
+      containers:
+        - name: porch-server
+          # Update image to the image of your porch apiserver build.
+          image: docker.io/nephio/porch-server:v2.0.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /cache
+              name: cache-volume
+            - mountPath: /etc/webhook/certs
+              name: webhook-certs
+            - name: api-server-certs
+              mountPath: /tmp/certs
+          env:
+            # Uncomment to enable trace-reporting to jaeger
+            #- name: OTEL
+            #  value: otel://jaeger-oltp:4317
+            - name: OTEL_SERVICE_NAME
+              value: porch-server
+            - name: CERT_STORAGE_DIR
+              value: /etc/webhook/certs
+            - name: USE_CERT_MAN_FOR_WEBHOOK
+              value: "true"
+          args:
+            - --function-runner=function-runner:9445
+            - --cache-directory=/cache
+            - --cert-dir=/tmp/certs
+            - --secure-port=4443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: porch-system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 4443
+      name: api
+    - port: 8443
+      protocol: TCP
+      targetPort: 8443
+      name: webhooks
+  selector:
+    app: porch-server

--- a/nephio/optional/porch-cert-manager-webhook/3-porch-server.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/3-porch-server.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: porch-server
           # Update image to the image of your porch apiserver build.
-          image: docker.io/nephio/porch-server:v2.0.0
+          image: docker.io/nephio/porch-server:v3.0.0
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/nephio/optional/porch-cert-manager-webhook/4-apiservice.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/4-apiservice.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.porch.kpt.dev
+spec:
+  insecureSkipTLSVerify: true
+  group: porch.kpt.dev
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: api
+    namespace: porch-system
+  version: v1alpha1

--- a/nephio/optional/porch-cert-manager-webhook/5-rbac.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/5-rbac.yaml
@@ -1,0 +1,132 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregated-apiserver-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - porch.kpt.dev
+    resources:
+      - functions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - config.porch.kpt.dev
+    resources:
+      - repositories
+      - repositories/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - porch.kpt.dev
+    resources:
+      - packagerevisions
+      - packagerevisions/status
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - config.porch.kpt.dev
+    resources:
+      - packagerevs
+      - packagerevs/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Needed for priority and fairness
+  - apiGroups:
+      - flowcontrol.apiserver.k8s.io
+    resources:
+      - flowschemas
+      - prioritylevelconfigurations
+    verbs:
+      - get
+      - watch
+      - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregated-apiserver-role
+  namespace: porch-system
+rules:
+  # Needed for workload identity
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: porch-function-executor
+  namespace: porch-fn-system
+rules:
+  # Needed to launch / read function executor pods
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - patch
+      - get
+      - watch
+      - list

--- a/nephio/optional/porch-cert-manager-webhook/6-rbac-bind.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/6-rbac-bind.yaml
@@ -1,0 +1,53 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sample-apiserver-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregated-apiserver-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: porch-server
+    namespace: porch-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sample-apiserver-rolebinding
+  namespace: porch-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aggregated-apiserver-role
+subjects:
+  - kind: ServiceAccount
+    name: porch-server
+    namespace: porch-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: porch-function-executor
+  namespace: porch-fn-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: porch-function-executor
+subjects:
+  - kind: ServiceAccount
+    name: porch-fn-runner
+    namespace: porch-system

--- a/nephio/optional/porch-cert-manager-webhook/7-auth-reader.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/7-auth-reader.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: porch-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: porch-server
+  namespace: porch-system

--- a/nephio/optional/porch-cert-manager-webhook/8-auth-delegator.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/8-auth-delegator.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: porch:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: porch-server
+  namespace: porch-system

--- a/nephio/optional/porch-cert-manager-webhook/9-controllers.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/9-controllers.yaml
@@ -1,0 +1,49 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: porch-controllers
+  namespace: porch-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: porch-controllers
+  namespace: porch-system
+  labels:
+    k8s-app: porch-controllers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: porch-controllers
+  template:
+    metadata:
+      labels:
+        k8s-app: porch-controllers
+    spec:
+      serviceAccountName: porch-controllers
+      containers:
+        - name: porch-controllers
+          # Update to the image of your porch-controllers build.
+          image: docker.io/nephio/porch-controllers:v2.0.0
+          imagePullPolicy: IfNotPresent
+          # Note: only the existence of the variable matters for enabling the reconciler
+          # So, be sure to remove the var not just change the value to false
+          env:
+            - name: ENABLE_PACKAGEVARIANTSETS
+              value: "true"
+            - name: ENABLE_PACKAGEVARIANTS
+              value: "true"

--- a/nephio/optional/porch-cert-manager-webhook/9-porch-controller-clusterrole.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/9-porch-controller-clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: porch-controllers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariants-clusterrole.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariants-clusterrole.yaml
@@ -1,0 +1,56 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: porch-controllers-packagevariants
+rules:
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - porch.kpt.dev
+  resources:
+  - packagerevisionresources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - porch.kpt.dev
+  resources:
+  - packagerevisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariants-clusterrolebinding.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariants-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: porch-system:porch-controllers-packagevariants
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: porch-controllers-packagevariants
+subjects:
+- kind: ServiceAccount
+  name: porch-controllers
+  namespace: porch-system

--- a/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariantsets-clusterrole.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariantsets-clusterrole.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: porch-controllers-packagevariantsets
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariantsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariantsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariantsets/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariantsets-clusterrolebinding.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/9-porch-controller-packagevariantsets-clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: porch-system:porch-controllers-packagevariantsets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: porch-controllers-packagevariantsets
+subjects:
+- kind: ServiceAccount
+  name: porch-controllers
+  namespace: porch-system

--- a/nephio/optional/porch-cert-manager-webhook/Kptfile
+++ b/nephio/optional/porch-cert-manager-webhook/Kptfile
@@ -1,0 +1,6 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: porch
+info:
+  description: porch package


### PR DESCRIPTION
This change is related to https://github.com/nephio-project/nephio/issues/554 and previous PR https://github.com/nephio-project/porch/pull/53

This PR implements an optional porch package which can be used to allow web-hooks to be externally defined in yaml files, have cert manager automatically create and update the certificates which these web-hooks will utilize.

This optional package Requires cert manager to be installed in the system and as such to not make porch dependent on cert manager has been made optional.

Note: The version used for the porch-server image is set to v3.0.0 which does not exist yet as it requires the code written in the previously mentioned porch PR to function and as such v2.0.0 would not work.