### PR TITLE
Adding missing repository for ueransim tool

### DIFF
--- a/nephio/optional/stock-repos/repo-tool-packages.yaml
+++ b/nephio/optional/stock-repos/repo-tool-packages.yaml
@@ -1,0 +1,16 @@
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: Repository
+metadata:
+  name: catalog-workloads-tools
+  namespace: default
+  labels:
+    kpt.dev/repository-access: read-only
+    kpt.dev/repository-content: external-blueprints
+spec:
+  content: Package
+  deployment: false
+  git:
+    branch: main
+    directory: /workloads/tools
+    repo: https://github.com/nephio-project/catalog.git
+  type: git


### PR DESCRIPTION
Ueransim tool repository was missing from nephio-stock folder