### PR TITLE
Fix function render on the infra/capi/nephio-workload-cluster package

### DIFF
--- a/infra/capi/nephio-workload-cluster/pv-configsync.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-configsync.yaml
@@ -12,6 +12,9 @@ spec:
   downstream:
     package: example-configsync
     repo: mgmt-staging
+  injectors:
+  - kind: WorkloadCluster
+    name: example
   pipeline:
     mutators:
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4

--- a/infra/capi/nephio-workload-cluster/pv-crds.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-crds.yaml
@@ -12,6 +12,9 @@ spec:
   downstream:
     package: example-crds
     repo: mgmt-staging
+  injectors:
+  - kind: WorkloadCluster
+    name: example
   pipeline:
     mutators:
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4

--- a/infra/capi/nephio-workload-cluster/pv-kindnet.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-kindnet.yaml
@@ -12,6 +12,9 @@ spec:
   downstream:
     package: example-kindnet
     repo: mgmt-staging
+  injectors:
+  - kind: WorkloadCluster
+    name: example
   pipeline:
     mutators:
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4

--- a/infra/capi/nephio-workload-cluster/pv-local-path-provisioner.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-local-path-provisioner.yaml
@@ -12,6 +12,9 @@ spec:
   downstream:
     package: example-local-path-provisioner
     repo: mgmt-staging
+  injectors:
+  - kind: WorkloadCluster
+    name: example
   pipeline:
     mutators:
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4

--- a/infra/capi/nephio-workload-cluster/pv-metallb.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-metallb.yaml
@@ -12,6 +12,9 @@ spec:
   downstream:
     package: example-metallb
     repo: mgmt-staging
+  injectors:
+  - kind: WorkloadCluster
+    name: example
   pipeline:
     mutators:
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4

--- a/infra/capi/nephio-workload-cluster/pv-multus.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-multus.yaml
@@ -12,6 +12,9 @@ spec:
   downstream:
     package: example-multus
     repo: mgmt-staging
+  injectors:
+  - kind: WorkloadCluster
+    name: example
   pipeline:
     mutators:
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4


### PR DESCRIPTION
It looks like something changed with the the apply-replacements function. Now, all resources that match the pattern specified in the ApplyReplacements resources must have the field specified.

This error is showing up on the end to end tests on the v3.0.0 tagged version but also on main.

To reproduce:
```
porchctl rpkg clone -n default https://github.com/nephio-project/catalog.git/infra/capi/nephio-workload-cluster@v3.0.0 --repository mgmt regional
Error: Internal error occurred: fn.render: pkg /:
	pkg.render:
	pipeline.run: error: function failure
```

or on main
```
porchctl rpkg clone -n default https://github.com/Nordix/catalog.git/infra/capi/nephio-workload-cluster@main --repository mgmt regional
Error: Internal error occurred: fn.render: pkg /:
	pkg.render:
	pipeline.run: error: function failure 
```

This PR fixes the issue, see
```
porchctl rpkg clone -n default https://github.com/Nordix/catalog.git/infra/capi/nephio-workload-cluster@add-injectors-to-workload-clusters --repository mgmt regional
mgmt-08c26219f9879acdefed3469f8c3cf89d5db3868 created
```

The Porch server log showed this:
```
I0704 06:26:59.643524       1 render.go:62] Package "/": 
I0704 06:26:59.644543       1 render.go:62] [RUNNING] "gcr.io/kpt-fn/apply-replacements:v0.1.1"
I0704 06:26:59.644551       1 render.go:62] 
I0704 06:26:59.657371       1 render.go:62] [FAIL] "gcr.io/kpt-fn/apply-replacements:v0.1.1" in 0s
I0704 06:26:59.657401       1 render.go:62]   Results:
    [error]: unable to find field "spec.injectors.[kind=WorkloadCluster].name" in replacement target
```

The issue is that some of the PackageVariant resources in the package do not have a "spec.injectors.[kind=WorkloadCluster].name" field. This PR adds that field to the PVs that miss it.

1. It's a pity that we have to dig in the logs for the `kpt fn render` error messages.
2. Why is the the apply-replacements kpt function acting like this all of a sudden?


