### PR TITLE
Revert reference in rootsync to main branch for gitea repos

### DIFF
--- a/nephio/optional/rootsync/rootsync.yaml
+++ b/nephio/optional/rootsync/rootsync.yaml
@@ -7,7 +7,7 @@ spec:
   sourceFormat: unstructured
   git:
     repo: http://172.18.0.200:3000/nephio/example-cluster-name.git
-    branch: v3.0.0
+    branch: main
     auth: token
     secretRef:
       name: example-cluster-name-access-token-configsync


### PR DESCRIPTION
The rootsync resource should pull from the main branch of the gitea repo on the management cluster.