### PR TITLE
Reference fixes for the v3.0.0 branch

### DIFF
--- a/distros/gcp/nephio-mgmt/nephio-controllers/Kptfile
+++ b/distros/gcp/nephio-mgmt/nephio-controllers/Kptfile
@@ -9,14 +9,14 @@ upstream:
   git:
     repo: https://github.com/nephio-project/nephio-example-packages
     directory: /nephio-controllers
-    ref: v1.0.1
+    ref: v3.0.0
   updateStrategy: resource-merge
 upstreamLock:
   type: git
   git:
     repo: https://github.com/nephio-project/nephio-example-packages
     directory: /nephio-controllers
-    ref: v1.0.1
+    ref: v3.0.0
     commit: 31ee80981fd0fb247a83b54f825f1b9ee86dee23
 info:
   description: nephio controller

--- a/distros/gcp/nephio-mgmt/nephio-controllers/Kptfile
+++ b/distros/gcp/nephio-mgmt/nephio-controllers/Kptfile
@@ -11,12 +11,5 @@ upstream:
     directory: /nephio-controllers
     ref: v3.0.0
   updateStrategy: resource-merge
-upstreamLock:
-  type: git
-  git:
-    repo: https://github.com/nephio-project/nephio-example-packages
-    directory: /nephio-controllers
-    ref: v3.0.0
-    commit: 31ee80981fd0fb247a83b54f825f1b9ee86dee23
 info:
   description: nephio controller

--- a/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-controller.yaml
@@ -78,7 +78,7 @@ spec:
           value: "true"
         - name: CLIENT_PROXY_ADDRESS
           value: resource-backend-controller-grpc-svc.backend-system.svc.cluster.local:9999
-        image: docker.io/nephio/nephio-operator:latest
+        image: docker.io/nephio/nephio-operator:v3.0.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-token-controller.yaml
+++ b/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-token-controller.yaml
@@ -76,7 +76,7 @@ spec:
           value: gitea
         - name: ENABLE_TOKENS
           value: "true"
-        image: docker.io/nephio/nephio-operator:latest
+        image: docker.io/nephio/nephio-operator:v3.0.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/distros/gcp/nephio-mgmt/nephio-webui/Kptfile
+++ b/distros/gcp/nephio-mgmt/nephio-webui/Kptfile
@@ -27,5 +27,5 @@ pipeline:
       configPath: apply-replacements.yaml
     - image: gcr.io/kpt-fn/starlark:v0.5.0
       configPath: set-auth.yaml
-    - image: docker.io/nephio/gen-configmap-fn:v2.0.0
+    - image: docker.io/nephio/gen-configmap-fn:v3.0.0
       configPath: gen-configmap.yaml

--- a/distros/gcp/nephio-mgmt/network-config/Kptfile
+++ b/distros/gcp/nephio-mgmt/network-config/Kptfile
@@ -9,14 +9,14 @@ upstream:
   git:
     repo: https://github.com/nephio-project/nephio-example-packages
     directory: /network-config
-    ref: v1.0.1
+    ref: v3.0.0
   updateStrategy: resource-merge
 upstreamLock:
   type: git
   git:
     repo: https://github.com/nephio-project/nephio-example-packages
     directory: /network-config
-    ref: v1.0.1
+    ref: v3.0.0
     commit: 31ee80981fd0fb247a83b54f825f1b9ee86dee23
 info:
   description: network-config controller

--- a/distros/gcp/nephio-mgmt/network-config/Kptfile
+++ b/distros/gcp/nephio-mgmt/network-config/Kptfile
@@ -11,12 +11,5 @@ upstream:
     directory: /network-config
     ref: v3.0.0
   updateStrategy: resource-merge
-upstreamLock:
-  type: git
-  git:
-    repo: https://github.com/nephio-project/nephio-example-packages
-    directory: /network-config
-    ref: v3.0.0
-    commit: 31ee80981fd0fb247a83b54f825f1b9ee86dee23
 info:
   description: network-config controller

--- a/distros/gcp/nephio-mgmt/network-config/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/network-config/app/controller/deployment-controller.yaml
@@ -74,7 +74,7 @@ spec:
           value: "true"
         - name: ENABLE_NETWORKCONFIGS
           value: "true"
-        image: docker.io/nephio/network-config-operator:latest
+        image: docker.io/nephio/network-config-operator:v3.0.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/distros/gcp/nephio-mgmt/resource-backend/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/resource-backend/app/controller/deployment-controller.yaml
@@ -86,7 +86,7 @@ spec:
           value: "true"
         - name: ENABLE_RAWTOPOLOGIES
           value: "true"
-        image: docker.io/nephio/resource-backend-controller:latest
+        image: docker.io/nephio/resource-backend-controller:v3.0.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/nephio/optional/stock-repos/repo-oai-core-packages.yaml
+++ b/nephio/optional/stock-repos/repo-oai-core-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: r3
+    branch: v3.0.0
     directory: /
     repo: https://github.com/OPENAIRINTERFACE/oai-packages.git
   type: git

--- a/nephio/optional/stock-repos/repo-oai-core-packages.yaml
+++ b/nephio/optional/stock-repos/repo-oai-core-packages.yaml
@@ -10,7 +10,7 @@ spec:
   content: Package
   deployment: false
   git:
-    branch: v3.0.0
+    branch: r3
     directory: /
     repo: https://github.com/OPENAIRINTERFACE/oai-packages.git
   type: git


### PR DESCRIPTION
Some more fixes for the v3.0.0 branch.

Perhaps we should eliminate this branch altogether and use R3, and tag R3 with v3.0.0