### PR TITLE
adds securityContext section for the container

### DIFF
--- a/nephio/core/porch/3-porch-server.yaml
+++ b/nephio/core/porch/3-porch-server.yaml
@@ -45,6 +45,10 @@ spec:
           # Update image to the image of your porch apiserver build.
           image: docker.io/nephio/porch-server:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           resources:
             requests:
               memory: 256Mi


### PR DESCRIPTION
When deploying porch-server on OpenShift, the below error is encountered

`Error: container create failed: time="2024-07-29T19:50:53Z" level=error msg="runc create failed: unable to start container process: exec: \"/home/nonroot/porch\": stat /home/nonroot/porch: permission denied"`

The fix is to update the container portion of the spec to add securityContext and specify that the container has to be run as non root and specify the uid and gid,