### PR TITLE
Update porch catalog with securityContext (https://github.com/nephio-project/catalog/pull/70)

### DIFF
--- a/nephio/core/porch/3-porch-server.yaml
+++ b/nephio/core/porch/3-porch-server.yaml
@@ -45,6 +45,10 @@ spec:
           # Update image to the image of your porch apiserver build.
           image: docker.io/nephio/porch-server:v3.0.0
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
           resources:
             requests:
               memory: 256Mi


### PR DESCRIPTION
This is a patch to include https://github.com/nephio-project/catalog/pull/70 into v3.0.0, as it is required for the testing Vish and I are doing on OCP. For more context please see the PR linked.