### PR TITLE
Update config-sync pkg to 1.18.3

### DIFF
--- a/nephio/core/configsync/config-management-operator.yaml
+++ b/nephio/core/configsync/config-management-operator.yaml
@@ -1,10 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata: # kpt-merge: /configmanagements.configmanagement.gke.io
+metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
-    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|configmanagements.configmanagement.gke.io'
-  
   name: configmanagements.configmanagement.gke.io
 spec:
   group: configmanagement.gke.io
@@ -21,10 +33,14 @@ spec:
         description: ConfigManagement is the Schema for the ConfigManagement API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -36,105 +52,162 @@ spec:
             description: ConfigManagementSpec defines the desired state of ConfigManagement.
             properties:
               ConfigSyncDisableFSWatcher:
-                description: ConfigSyncDisableFSWatcher provides the ability to disable the fs-watcher process.  This field is intentionally left hidden/undocumented since it is only meant to be used by customers who have very large repositories. Optional.
+                description: ConfigSyncDisableFSWatcher provides the ability to disable
+                  the fs-watcher process.  This field is intentionally left hidden/undocumented
+                  since it is only meant to be used by customers who have very large
+                  repositories. Optional.
                 type: boolean
               ConfigSyncLogLevel:
-                description: ConfigSyncLogLevel overrides the logging verbosity for all ConfigSync pods. This field is intentionally left hidden/undocumented since it is really only used to gather extra logs for support cases.
+                description: ConfigSyncLogLevel overrides the logging verbosity for
+                  all ConfigSync pods. This field is intentionally left hidden/undocumented
+                  since it is really only used to gather extra logs for support cases.
                 type: integer
               binauthz:
-                description: BinAuthz enables Binary Authorization as recognized by the "binauthz.configmanagement.gke.io" label set to "true".
+                description: 'Deprecated: Does nothing. binauthz can no longer be
+                  enabled/disabled with the ConfigManagement resource; the software
+                  is available as a standalone: https://cloud.google.com/binary-authorization'
                 properties:
                   enabled:
                     description: 'Enable or disable BinAuthz.  Default: false.'
                     type: boolean
                   policyRef:
-                    description: PolicyRef is a reference to the BinAuthz policy which will be evaluated. Required if BinAuthz is enabled.
+                    description: PolicyRef is a reference to the BinAuthz policy which
+                      will be evaluated. Required if BinAuthz is enabled.
                     properties:
                       gkeCluster:
-                        description: BinAuthz policy associated with this GKE-on-GCP cluster.
+                        description: BinAuthz policy associated with this GKE-on-GCP
+                          cluster.
                         properties:
                           location:
                             description: Location of this cluster
                             type: string
                           name:
-                            description: The name of this cluster according to GKE. This is not necessarily the same as the hub membership name.
+                            description: The name of this cluster according to GKE.
+                              This is not necessarily the same as the hub membership
+                              name.
                             type: string
                           project:
-                            description: The name of the GCP project containing this cluster
+                            description: The name of the GCP project containing this
+                              cluster
                             type: string
                         type: object
                     type: object
                 type: object
               channel:
-                description: 'Channel specifies a channel that can be used to resolve a specific addon, eg: stable It will be ignored if Version is specified'
+                description: 'Channel specifies a channel that can be used to resolve
+                  a specific addon, eg: stable It will be ignored if Version is specified'
                 type: string
               clusterName:
-                description: ClusterName, if defined, sets the name for this cluster.  If unset, the cluster is considered to be unnamed, and cannot use ClusterSelectors.
+                description: ClusterName, if defined, sets the name for this cluster.  If
+                  unset, the cluster is considered to be unnamed, and cannot use ClusterSelectors.
                 type: string
               configConnector:
-                description: 'Deprecated: Does nothing.  ConfigConnector can no longer be enabled/disabled with the ConfigManagement resource; the software is available as a standalone: https://cloud.google.com/config-connector'
+                description: 'Deprecated: Does nothing.  ConfigConnector can no longer
+                  be enabled/disabled with the ConfigManagement resource; the software
+                  is available as a standalone: https://cloud.google.com/config-connector'
                 properties:
                   enabled:
-                    description: 'Enable or disable the Config Connector.  Default: false.'
+                    description: 'Enable or disable the Config Connector.  Default:
+                      false.'
                     type: boolean
                 type: object
               enableLegacyFields:
-                description: EnableLegacyFields instructs the operator to use spec.git for generating a RootSync resource in MultiRepo mode. Note that this should only be set to true if spec.enableMultiRepo is set to true.
+                description: EnableLegacyFields instructs the operator to use spec.git
+                  for generating a RootSync resource in MultiRepo mode. Note that
+                  this should only be set to true if spec.enableMultiRepo is set to
+                  true.
                 type: boolean
               enableMultiRepo:
-                description: EnableMultiRepo instructs the operator to enable Multi Repo mode for Config Sync.
+                description: EnableMultiRepo instructs the operator to enable Multi
+                  Repo mode for Config Sync.
                 type: boolean
               git:
-                description: Git contains configuration specific to importing policies from a Git repo.
+                description: Git contains configuration specific to importing policies
+                  from a Git repo.
                 properties:
                   gcpServiceAccountEmail:
-                    description: 'GCPServiceAccountEmail specifies the GCP service account used to annotate the Config Sync Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    description: 'GCPServiceAccountEmail specifies the GCP service
+                      account used to annotate the Config Sync Kubernetes Service
+                      Account. Note: The field is used when secretType: gcpServiceAccount.'
                     type: string
                   policyDir:
-                    description: 'PolicyDir is the absolute path of the directory that contains the local policy.  Default: the root directory of the repo.'
+                    description: 'PolicyDir is the absolute path of the directory
+                      that contains the local policy.  Default: the root directory
+                      of the repo.'
                     type: string
                   proxy:
-                    description: Proxy is a struct that contains options for configuring access to the Git repo via a proxy. Only has an effect when secretType is one of ("cookiefile", "none").  Optional.
+                    description: Proxy is a struct that contains options for configuring
+                      access to the Git repo via a proxy. Only has an effect when
+                      secretType is one of ("cookiefile", "none").  Optional.
                     properties:
                       httpProxy:
-                        description: HTTPProxy defines a HTTP_PROXY env variable used to access the Git repo.  If both HTTPProxy and HTTPSProxy are specified, HTTPProxy will be ignored. Optional.
+                        description: HTTPProxy defines a HTTP_PROXY env variable used
+                          to access the Git repo.  If both HTTPProxy and HTTPSProxy
+                          are specified, HTTPProxy will be ignored. Optional.
                         type: string
                       httpsProxy:
-                        description: HTTPSProxy defines a HTTPS_PROXY env variable used to access the Git repo.  If both HTTPProxy and HTTPSProxy are specified, HTTPProxy will be ignored. Optional.
+                        description: HTTPSProxy defines a HTTPS_PROXY env variable
+                          used to access the Git repo.  If both HTTPProxy and HTTPSProxy
+                          are specified, HTTPProxy will be ignored. Optional.
                         type: string
                     type: object
                   secretType:
-                    description: SecretType is the type of secret configured for access to the Git repo. Must be one of ssh, cookiefile, gcenode, token, gcpserviceaccount or none. Required. The validation of this is case-sensitive.
+                    description: SecretType is the type of secret configured for access
+                      to the Git repo. Must be one of ssh, cookiefile, gcenode, token,
+                      gcpserviceaccount or none. Required. The validation of this
+                      is case-sensitive.
                     pattern: ^(ssh|cookiefile|gcenode|gcpserviceaccount|token|none)$
                     type: string
                   syncBranch:
-                    description: 'SyncBranch is the branch to sync from.  Default: "master".'
+                    description: 'SyncBranch is the branch to sync from.  Default:
+                      "master".'
                     type: string
                   syncRepo:
                     pattern: ^(((https?|git|ssh):\/\/)|git@)
                     type: string
                   syncRev:
-                    description: 'SyncRev is the git revision (tag or hash) to check out. Default: HEAD.'
+                    description: 'SyncRev is the git revision (tag or hash) to check
+                      out. Default: HEAD.'
                     type: string
                   syncWait:
-                    description: 'SyncWaitSeconds is the time duration in seconds between consecutive syncs.  Default: 15 seconds. Note that SyncWaitSecs is not a time.Duration on purpose. This provides a reminder to developers that customers specify this value using using integers like "3" in their ConfigManagement YAML. However, time.Duration is at a nanosecond granularity, and it''s easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    description: 'SyncWaitSeconds is the time duration in seconds
+                      between consecutive syncs.  Default: 15 seconds. Note that SyncWaitSecs
+                      is not a time.Duration on purpose. This provides a reminder
+                      to developers that customers specify this value using using
+                      integers like "3" in their ConfigManagement YAML. However, time.Duration
+                      is at a nanosecond granularity, and it''s easy to introduce
+                      a bug where it looks like the code is dealing with seconds but
+                      its actually nanoseconds (or vice versa).'
                     type: integer
                 type: object
               hierarchyController:
-                description: Hierarchy Controller enables HierarchyController components as recognized by the "hierarchycontroller.configmanagement.gke.io" label set to "true".
+                description: Hierarchy Controller enables HierarchyController components
+                  as recognized by the "hierarchycontroller.configmanagement.gke.io"
+                  label set to "true".
                 properties:
                   enableHierarchicalResourceQuota:
-                    description: 'HierarchicalResourceQuota enforces resource quota in a hierarchical fashion: a resource quota set for one namespace provides constraints that limit aggregate resource consumption for that namespace and all its descendants. Disabling this will not delete user created hrq CRs, but will delete all the intermediate resources created by HRQ (specifically the resource quota singletons), which are labeled with hierarchycontroller.configmanagement.gke.io/hrq for easier cleanup.'
+                    description: 'HierarchicalResourceQuota enforces resource quota
+                      in a hierarchical fashion: a resource quota set for one namespace
+                      provides constraints that limit aggregate resource consumption
+                      for that namespace and all its descendants. Disabling this will
+                      not delete user created hrq CRs, but will delete all the intermediate
+                      resources created by HRQ (specifically the resource quota singletons),
+                      which are labeled with hierarchycontroller.configmanagement.gke.io/hrq
+                      for easier cleanup.'
                     type: boolean
                   enablePodTreeLabels:
-                    description: PodTreeLabels copies the tree labels from namespaces to pods, allowing any system that uses pod logs (such as Stackdriver logging) to inspect the hierarchy.
+                    description: PodTreeLabels copies the tree labels from namespaces
+                      to pods, allowing any system that uses pod logs (such as Stackdriver
+                      logging) to inspect the hierarchy.
                     type: boolean
                   enabled:
-                    description: 'Enable or disable the Hierarchy Controller.  Default: false.'
+                    description: 'Enable or disable the Hierarchy Controller.  Default:
+                      false.'
                     type: boolean
                 type: object
               importer:
-                description: Importer allows one to override the existing resource requirements for the importer pod
+                description: Importer allows one to override the existing resource
+                  requirements for the importer pod
                 properties:
                   limits:
                     additionalProperties:
@@ -143,7 +216,8 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -152,31 +226,52 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              metricsGCPServiceAccountEmail:
+                description: MetricsGCPServiceAccountEmail specifies a Google Service
+                  Account (GSA) Email with the Monitoring Metric Writer (roles/monitoring.metricWriter)
+                  IAM role. This GSA Email is used to annotate the `default` Kubernetes
+                  ServiceAccount under the `config-management-monitoring` namespace,
+                  which allows Config Sync to export metrics to Cloud Monitoring.
+                type: string
               patches:
                 items:
                   type: object
                 type: array
                 x-kubernetes-preserve-unknown-fields: true
               policyController:
-                description: Policy Controller enables PolicyController components as recognized by the "gatekeeper.sh/manifest" label set to "true".
+                description: 'Deprecated: Does nothing. Policy Controller can no longer
+                  be enabled/disabled with the ConfigManagement resource; see https://cloud.google.com/anthos-config-management/docs/how-to/installing-policy-controller
+                  for supported ways of enabling Policy Controller.'
                 properties:
                   auditIntervalSeconds:
-                    description: AuditIntervalSeconds. The number of seconds between audit runs. Defaults to 60 seconds. To disable audit, set this to 0.
+                    description: AuditIntervalSeconds. The number of seconds between
+                      audit runs. Defaults to 60 seconds. To disable audit, set this
+                      to 0.
                     format: int64
                     type: integer
                   enabled:
-                    description: 'Enable or disable the Policy Controller.  Default: false.'
+                    description: 'Enable or disable the Policy Controller.  Default:
+                      false.'
                     type: boolean
                   exemptableNamespaces:
-                    description: ExemptableNamespaces. The namespaces in this list are able to have the admission.gatekeeper.sh/ignore label set. When the label is set, Policy Controller will not be called for that namespace or any resources contained in it. `gatekeeper-system` is always exempted.
+                    description: ExemptableNamespaces. The namespaces in this list
+                      are able to have the admission.gatekeeper.sh/ignore label set.
+                      When the label is set, Policy Controller will not be called
+                      for that namespace or any resources contained in it. `gatekeeper-system`
+                      is always exempted.
                     items:
                       type: string
                     type: array
                   logDeniesEnabled:
-                    description: 'LogDeniesEnabled.  If true, Policy Controller will log all denies and dryrun failures.  No effect unless policyController is enabled.  Default: false.'
+                    description: 'LogDeniesEnabled.  If true, Policy Controller will
+                      log all denies and dryrun failures.  No effect unless policyController
+                      is enabled.  Default: false.'
                     type: boolean
                   monitoring:
                     description: Monitoring specifies the configuration of monitoring.
@@ -187,28 +282,46 @@ spec:
                         type: array
                     type: object
                   mutation:
-                    description: Mutation specifies the configuration of mutation. This is a preview feature and may change before becoming generally available.
+                    description: Mutation specifies the configuration of mutation.
+                      This is a preview feature and may change before becoming generally
+                      available.
                     properties:
                       enabled:
-                        description: 'Enable or disable mutation in policy controller. If true, mutation CRDs, webhook and controller will be deployed to the cluster. Default: false.'
+                        description: 'Enable or disable mutation in policy controller.
+                          If true, mutation CRDs, webhook and controller will be deployed
+                          to the cluster. Default: false.'
                         type: boolean
                     type: object
                   referentialRulesEnabled:
-                    description: 'ReferentialRulesEnabled.  If true, Policy Controller will allow `data.inventory` references in the contents of ConstraintTemplate Rego.  No effect unless policyController is enabled.  Default: false.'
+                    description: 'ReferentialRulesEnabled.  If true, Policy Controller
+                      will allow `data.inventory` references in the contents of ConstraintTemplate
+                      Rego.  No effect unless policyController is enabled.  Default:
+                      false.'
                     type: boolean
                   templateLibraryInstalled:
-                    description: 'TemplateLibraryInstalled.  If true, a set of default ConstraintTemplates will be deployed to the cluster. ConstraintTemplates will not be deployed if this is explicitly set to false or if policyController is not enabled. Default: true.'
+                    description: 'TemplateLibraryInstalled.  If true, a set of default
+                      ConstraintTemplates will be deployed to the cluster. ConstraintTemplates
+                      will not be deployed if this is explicitly set to false or if
+                      policyController is not enabled. Default: true.'
                     type: boolean
                 type: object
               preventDrift:
-                description: 'preventDrift, if set to `true`, enables the Config Sync admission webhook to prevent drifts. If set to `false`, disables the Config Sync admission webhook and does not prevent drifts. Default: false. Config Sync always corrects drifts no matter the value of preventDrift.'
+                description: 'preventDrift, if set to `true`, enables the Config Sync
+                  admission webhook to prevent drifts. If set to `false`, disables
+                  the Config Sync admission webhook and does not prevent drifts. Default:
+                  false. Config Sync always corrects drifts no matter the value of
+                  preventDrift.'
                 type: boolean
               sourceFormat:
-                description: "SourceFormat specifies how the repository is formatted. See documentation for specifics of what these options do. \n Must be one of hierarchy, unstructured. Optional. Set to hierarchy if not specified. \n The validation of this is case-sensitive."
+                description: "SourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do. \n Must
+                  be one of hierarchy, unstructured. Optional. Set to hierarchy if
+                  not specified. \n The validation of this is case-sensitive."
                 pattern: ^(hierarchy|unstructured|)$
                 type: string
               syncer:
-                description: Syncer allows one to override the existing resource requirements for the syncer pod
+                description: Syncer allows one to override the existing resource requirements
+                  for the syncer pod
                 properties:
                   limits:
                     additionalProperties:
@@ -217,7 +330,8 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -226,18 +340,24 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               version:
-                description: Version specifies the exact addon version to be deployed, eg 1.2.3 It should not be specified if Channel is specified
+                description: Version specifies the exact addon version to be deployed,
+                  eg 1.2.3 It should not be specified if Channel is specified
                 type: string
             type: object
           status:
             description: ConfigManagementStatus defines the observed state of ConfigManagement.
             properties:
               configManagementVersion:
-                description: ConfigManagementVersion is the semantic version number of the config management system enforced by the currently running config management operator.
+                description: ConfigManagementVersion is the semantic version number
+                  of the config management system enforced by the currently running
+                  config management operator.
                 type: string
               errors:
                 items:
@@ -259,21 +379,17 @@ spec:
 ---
 apiVersion: v1
 kind: Namespace
-metadata: # kpt-merge: /config-management-system
+metadata:
   name: config-management-system
   labels:
     configmanagement.gke.io/system: "true"
-  annotations:
-    internal.kpt.dev/upstream-identifier: '|Namespace|default|config-management-system'
 ---
 apiVersion: v1
 kind: Namespace
-metadata: # kpt-merge: /config-management-monitoring
+metadata:
   name: config-management-monitoring
   labels:
     configmanagement.gke.io/system: "true"
-  annotations:
-    internal.kpt.dev/upstream-identifier: '|Namespace|default|config-management-monitoring'
 ---
 # The Nomos system creates RBAC rules, so it requires
 # full cluster-admin access. Thus, the operator needs
@@ -281,12 +397,10 @@ metadata: # kpt-merge: /config-management-monitoring
 # Nomos components.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-metadata: # kpt-merge: /config-management-operator
+metadata:
   labels:
     k8s-app: config-management-operator
   name: config-management-operator
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|config-management-operator'
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -294,12 +408,10 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata: # kpt-merge: /config-management-operator
+metadata:
   labels:
     k8s-app: config-management-operator
   name: config-management-operator
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|config-management-operator'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -311,24 +423,23 @@ subjects:
 ---
 apiVersion: v1
 kind: ServiceAccount
-metadata: # kpt-merge: config-management-system/config-management-operator
+metadata:
   labels:
     k8s-app: config-management-operator
   name: config-management-operator
   namespace: config-management-system
-  annotations:
-    internal.kpt.dev/upstream-identifier: '|ServiceAccount|config-management-system|config-management-operator'
 ---
 apiVersion: apps/v1
 kind: Deployment
-metadata: # kpt-merge: config-management-system/config-management-operator
+metadata:
   name: config-management-operator
   namespace: config-management-system
   labels:
     k8s-app: config-management-operator
-  annotations:
-    internal.kpt.dev/upstream-identifier: 'apps|Deployment|config-management-system|config-management-operator'
 spec:
+  # specifying replicas explicitly would help to enforce the intended
+  # value when the file is applied.
+  replicas: 1
   strategy:
     type: Recreate
     # must be null due to 3-way merge, as
@@ -349,11 +460,11 @@ spec:
         - /manager
         - --private-registry=
         name: manager
-        image: gcr.io/config-management-release/config-management-operator:20220617195442-op
+        image: gcr.io/config-management-release/config-management-operator:v1.18.3
         resources:
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 200Mi
         envFrom:
         - configMapRef:
             name: operator-environment-options
@@ -361,7 +472,13 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
       serviceAccount: config-management-operator
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/nephio/core/configsync/configsync.yaml
+++ b/nephio/core/configsync/configsync.yaml
@@ -1,6 +1,6 @@
 apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
-metadata: # kpt-merge: /config-management
+metadata:
   name: config-management
   annotations:
     config.kubernetes.io/depends-on: apiextensions.k8s.io/CustomResourceDefinition/configmanagements.configmanagement.gke.io

--- a/nephio/core/configsync/rootsync-crd.yaml
+++ b/nephio/core/configsync/rootsync-crd.yaml
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,10 +14,9 @@
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata: # kpt-merge: /rootsyncs.configsync.gke.io
+metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|rootsyncs.configsync.gke.io'
+    controller-gen.kubebuilder.io/version: v0.15.0
   labels:
     configmanagement.gke.io/arch: csmr
     configmanagement.gke.io/system: "true"
@@ -57,10 +56,19 @@ spec:
         description: RootSync is the Schema for the rootsyncs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -68,10 +76,14 @@ spec:
             description: RootSyncSpec defines the desired state of RootSync
             properties:
               git:
-                description: git contains configuration specific to importing resources from a Git repo.
+                description: git contains configuration specific to importing resources
+                  from a Git repo.
                 properties:
                   auth:
-                    description: auth is the type of secret configured for access to the Git repo. Must be one of ssh, cookiefile, gcenode, token, or none. The validation of this is case-sensitive. Required.
+                    description: |-
+                      auth is the type of secret configured for access to the Git repo.
+                      Must be one of ssh, cookiefile, gcenode, token, or none.
+                      The validation of this is case-sensitive. Required.
                     enum:
                     - ssh
                     - cookiefile
@@ -81,31 +93,74 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: 'branch is the git branch to checkout. Default: "master".'
+                    description: |-
+                      branch is the git branch to sync from.
+                      Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+                      'revision' takes precedence over 'branch'.
                     type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   dir:
-                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the repo.'
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the repo.
                     type: string
                   gcpServiceAccountEmail:
-                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when spec.git.auth: gcpserviceaccount.'
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.git.auth: gcpserviceaccount.
                     type: string
                   noSSLVerify:
-                    description: 'noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false. If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.'
+                    description: |-
+                      noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false.
+                      If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.
+                      This should either be false or unset when caCertSecretRef is provided.
                     type: boolean
                   period:
-                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
                     type: string
                   proxy:
-                    description: proxy specifies an HTTPS proxy for accessing the Git repo. Only has an effect when secretType is one of ("cookiefile", "none", "token"). When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information such as a username or password and you need to hide the sensitive information, you can leave this field empty and add the URL for the HTTPS proxy into the same Secret used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    description: |-
+                      proxy specifies an HTTPS proxy for accessing the Git repo.
+                      Only has an effect when secretType is one of ("cookiefile", "none", "token").
+                      When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information
+                      such as a username or password and you need to hide the sensitive information,
+                      you can leave this field empty and add the URL for the HTTPS proxy into the same Secret
+                      used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
                     type: string
                   repo:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (tag, ref or commit) to fetch. Default: "HEAD".'
+                    description: |-
+                      revision is the git revision (branch, tag, ref or commit) to fetch.
+                      If 'revision' is not specified, it defaults to the HEAD of the branch that
+                      is specified in the 'branch' field.
+                      If neither 'revision' nor 'branch' is specified, it defaults to the HEAD of
+                      the 'master' branch.
                     type: string
                   secretRef:
-                    description: secretRef is the secret used to connect to the Git source of truth.
+                    description: secretRef is the secret used to connect to the Git
+                      source of truth.
+                    nullable: true
                     properties:
                       name:
                         description: name represents the secret name.
@@ -116,29 +171,70 @@ spec:
                 - repo
                 type: object
               helm:
-                description: helm contains configuration specific to importing resources from a Helm repo.
+                description: helm contains configuration specific to importing resources
+                  from a Helm repo.
                 properties:
                   auth:
-                    description: auth specifies the type to authenticate to the Helm repository. Must be one of secret, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    description: |-
+                      auth specifies the type to authenticate to the Helm repository.
+                      Must be one of token, gcpserviceaccount, k8sserviceaccount, gcenode or none.
+                      The validation of this is case-sensitive. Required.
                     enum:
                     - none
                     - gcpserviceaccount
+                    - k8sserviceaccount
                     - token
+                    - gcenode
                     type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   chart:
                     description: chart is a Helm chart name. Required.
                     type: string
+                  deployNamespace:
+                    description: |-
+                      deployNamespace specifies the namespace in which to deploy the chart.
+                      This is a mutually exclusive setting with "namespace".
+                      If neither namespace nor deployNamespace are set, the chart will be
+                      deployed into the default namespace.
+                    type: string
                   gcpServiceAccountEmail:
-                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when spec.helm.auth: gcpserviceaccount.'
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.helm.auth: gcpserviceaccount.
                     type: string
                   includeCRDs:
-                    description: 'includeCRDs specifies if Helm template should also generate CustomResourceDefinitions. If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated. Default: false.'
+                    description: |-
+                      includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
+                      If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.
+                      Default: false.
                     type: boolean
                   namespace:
-                    description: namespace sets the target namespace for a release
+                    description: |-
+                      namespace sets the target namespace for a release.
+                      Default: "default".
                     type: string
                   period:
-                    description: 'period is the time duration between consecutive syncs. Default: 15s. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Chart will not be re-synced if version is specified and it is not "latest"'
+                    description: |-
+                      period is the time duration that Config Sync waits before refetching the chart.
+                      Default: 1 hour.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      If the chart version is a range, the literal tag "latest", or left empty to indicate that Config Sync
+                      should fetch the latest version, the chart will be re-fetched according to spec.helm.period.
+                      If the chart version is specified as a single static version, the chart will not be re-fetched.
                     type: string
                   releaseName:
                     description: releaseName is the name of the Helm release.
@@ -147,22 +243,53 @@ spec:
                     description: repo is the helm repository URL to sync from. Required.
                     type: string
                   secretRef:
-                    description: secretRef holds the authentication secret for accessing the Helm repository.
+                    description: |-
+                      secretRef holds the authentication secret for accessing
+                      the Helm repository.
+                    nullable: true
                     properties:
                       name:
                         description: name represents the secret name.
                         type: string
                     type: object
                   values:
-                    description: values to use instead of default values that accompany the chart
-                    type: object
-                  valuesFiles:
-                    description: valuesFiles is a list of path to Helm value files. Values files must be in the same repository with the Helm chart. And the paths here are absolute path from the root directory of the repository
+                    description: |-
+                      values to use instead of default values that accompany the chart. Format
+                      values the same as default values.yaml. If `valuesFileRefs` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    x-kubernetes-preserve-unknown-fields: true
+                  valuesFileRefs:
+                    description: |-
+                      valuesFileRefs holds references to objects in the cluster that represent
+                      values to use instead of default values that accompany the chart. Currently,
+                      only ConfigMaps are supported. The ConfigMaps must be immutable and in the same
+                      namespace as the RootSync/RepoSync. When multiple values files are specified, duplicated
+                      keys in later files will override the value from earlier files. This is equivalent
+                      to passing in multiple values files to Helm CLI. If `values` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
                     items:
-                      type: string
+                      description: |-
+                        ValuesFileRef references a ConfigMap object that contains a values file to use for
+                        helm rendering. The ConfigMap must be in the same namespace as the RootSync/RepoSync.
+                      properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the values from. Default: `values.yaml`'
+                          type: string
+                        name:
+                          description: name represents the Object name. Required.
+                          type: string
+                      type: object
                     type: array
                   version:
-                    description: version is the chart version. If this is not specified, the latest version is used
+                    description: |-
+                      version is the chart version.
+                      This can be specified as a static version, or as a range of values from which Config Sync
+                      will fetch the latest. If left empty, Config Sync will fetch the latest version according to semver.
+                      The supported version range syntax is identical to the version range syntax
+                      supported by helm CLI, and is documented here: https://github.com/Masterminds/semver#hyphen-range-comparisons.
+                      Versions specified as a range, the literal tag "latest", or left empty to indicate that Config Sync should
+                      fetch the latest version, will be fetched every sync according to spec.helm.period.
                     type: string
                 required:
                 - auth
@@ -170,26 +297,62 @@ spec:
                 - repo
                 type: object
               oci:
-                description: oci contains configuration specific to importing resources from an OCI package.
+                description: oci contains configuration specific to importing resources
+                  from an OCI package.
                 properties:
                   auth:
-                    description: auth is the type of secret configured for access to the OCI package. Must be one of gcenode, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    description: |-
+                      auth is the type of secret configured for access to the OCI package.
+                      Must be one of gcenode, gcpserviceaccount, k8sserviceaccount, or none.
+                      The validation of this is case-sensitive. Required.
                     enum:
                     - gcenode
                     - gcpserviceaccount
+                    - k8sserviceaccount
                     - none
                     type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   dir:
-                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the image.'
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the image.
                     type: string
                   gcpServiceAccountEmail:
-                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
                     type: string
                   image:
-                    description: 'image is the OCI image repository URL for the package to sync from. e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`. The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME. - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`. - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`. If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default. Required'
+                    description: |-
+                      image is the OCI image repository URL for the package to sync from.
+                      e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`.
+                      The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME.
+                      - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`.
+                      - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`.
+                      If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default.
+                      Required
                     type: string
                   period:
-                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
                     type: string
                 required:
                 - auth
@@ -199,68 +362,195 @@ spec:
                 description: override allows to override the settings for a reconciler.
                 nullable: true
                 properties:
+                  apiServerTimeout:
+                    description: |-
+                      apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+                      Default: 15s.
+                      Use string to specify this field value, like "30s", "1m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended apiServerTimeout range is from "3s" to "1m".
+                    type: string
                   enableShellInRendering:
-                    description: 'enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false. Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and support pulling remote bases from public repositories.'
+                    description: |-
+                      enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
+                      Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
+                      support pulling remote bases from public repositories.
                     type: boolean
                   gitSyncDepth:
-                    description: gitSyncDepth allows one to override the number of git commits to fetch. Must be no less than 0. Config Sync would do a full clone if this field is 0, and a shallow clone if this field is greater than 0. If this field is not provided, Config Sync would configure it automatically.
+                    description: |-
+                      gitSyncDepth allows one to override the number of git commits to fetch.
+                      Must be no less than 0.
+                      Config Sync would do a full clone if this field is 0, and a shallow
+                      clone if this field is greater than 0.
+                      If this field is not provided, Config Sync would configure it automatically.
                     format: int64
                     minimum: 0
                     type: integer
-                  reconcileTimeout:
-                    description: 'reconcileTimeout allows one to override the threshold for how long to wait for all resources to reconcile before giving up. Default: 5m. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended reconcileTimeout range is from "10s" to "1h".'
-                    type: string
-                  resources:
-                    description: resources allow one to override the resource requirements for the containers in a reconciler pod.
+                  logLevels:
+                    description: |-
+                      logLevels specify the container name and log level override value for the reconciler deployment container.
+                      Each entry must contain the name of the reconciler deployment container and the desired log level.
                     items:
-                      description: ContainerResourcesSpec allows to override the resource requirements for a container
+                      description: ContainerLogLevelOverride specifies the container
+                        name and log level override value
                       properties:
                         containerName:
-                          description: containerName specifies the name of a container whose resource requirements will be overridden. Must be "reconciler", "git-sync", "hydration-controller", or "oci-sync".
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync)$
+                          description: |-
+                            containerName specifies the name of the reconciler deployment container for which log level will be overridden.
+                            Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        logLevel:
+                          description: |-
+                            logLevel specifies the verbosity level of the logging for a specific container.
+                            The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+                            Increasing the value of logLevel increases the verbosity of the logs.
+                            Lower severity messages are logged at higher verbosity.
+                            Allowed values are from 0 to 10.
+                          maximum: 10
+                          minimum: 0
+                          type: integer
+                      required:
+                      - containerName
+                      - logLevel
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerName
+                    x-kubernetes-list-type: map
+                  namespaceStrategy:
+                    description: |-
+                      namespaceStrategy controls how the reconciler handles Namespaces
+                      which are used by resources in the source but not declared. Only applies
+                      when using the unstructured sourceFormat.
+                      Must be "implicit" or "explicit". Default: "implicit".
+                      "implicit" means that the reconciler will implicitly create Namespaces
+                      if they do not exist, even if they are not declared in the source.
+                      "explicit" means that the reconciler will not create Namespaces which
+                      are not declared in the source.
+                    enum:
+                    - implicit
+                    - explicit
+                    type: string
+                  reconcileTimeout:
+                    description: |-
+                      reconcileTimeout allows one to override the threshold for how long to wait for
+                      all resources to reconcile before giving up.
+                      Default: 5m.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended reconcileTimeout range is from "10s" to "1h".
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements
+                      for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource
+                        requirements for a container
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of a container whose resource requirements will be overridden.
+                            Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         cpuLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: cpuLimit allows one to override the CPU limit of a container
+                          description: cpuLimit allows one to override the CPU limit
+                            of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         cpuRequest:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: cpuRequest allows one to override the CPU request of a container
+                          description: cpuRequest allows one to override the CPU request
+                            of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         memoryLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: memoryLimit allows one to override the memory limit of a container
+                          description: memoryLimit allows one to override the memory
+                            limit of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         memoryRequest:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: memoryRequest allows one to override the memory request of a container
+                          description: memoryRequest allows one to override the memory
+                            request of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     type: array
+                  roleRefs:
+                    description: |-
+                      roleRefs is a list of Roles or ClusterRoles to create bindings.
+                      If unset, a binding to cluster-admin will be created.
+                    items:
+                      description: |-
+                        each item references a Role or ClusterRole to create
+                        a binding to for this reconciler. It supports a namespace field that can be used
+                        to create RoleBindings rather than ClusterRoleBindings.
+                      properties:
+                        kind:
+                          description: |-
+                            kind refers to the Kind of the RBAC resource.
+                            Accepted values are Role and ClusterRole. Required.
+                          enum:
+                          - Role
+                          - ClusterRole
+                          type: string
+                        name:
+                          description: name is the name of the Role or ClusterRole
+                            resource. Required.
+                          type: string
+                        namespace:
+                          description: |-
+                            namespace indicates the Namespace in which a RoleBinding should be created.
+                            For ClusterRole objects, will determine whether a RoleBinding or ClusterRoleBinding
+                            is created.
+                            For Role objects, must be set to the same namespace as the Role.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
                   statusMode:
-                    description: statusMode controls whether the actuation status such as apply failed or not should be embedded into the ResourceGroup object. Must be "enabled" or "disabled". If set to "enabled", it increases the size of the ResourceGroup object.
+                    description: |-
+                      statusMode controls whether the actuation status
+                      such as apply failed or not should be embedded into the ResourceGroup object.
+                      Must be "enabled" or "disabled".
+                      If set to "enabled", it increases the size of the ResourceGroup object.
                     pattern: ^(enabled|disabled|)$
                     type: string
                 type: object
               sourceFormat:
-                description: "sourceFormat specifies how the repository is formatted. See documentation for specifics of what these options do. \n Must be one of hierarchy, unstructured. Optional. Set to hierarchy if not specified. \n The validation of this is case-sensitive."
+                description: |-
+                  sourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do.
+
+
+                  Must be one of hierarchy, unstructured. Optional. Set to
+                  hierarchy if not specified.
+
+
+                  The validation of this is case-sensitive.
                 pattern: ^(hierarchy|unstructured|)$
                 type: string
               sourceType:
                 default: git
-                description: "sourceType specifies the type of the source of truth. \n Must be one of git, oci, helm. Optional. Set to git if not specified."
+                description: |-
+                  sourceType specifies the type of the source of truth.
+
+
+                  Must be one of git, oci, helm. Optional. Set to git if not specified.
                 pattern: ^(git|oci|helm)$
                 type: string
             type: object
@@ -268,50 +558,75 @@ spec:
             description: RootSyncStatus defines the observed state of RootSync
             properties:
               conditions:
-                description: conditions represents the latest available observations of the RootSync's current state.
+                description: |-
+                  conditions represents the latest available observations of the RootSync's
+                  current state.
                 items:
-                  description: RootSyncCondition describes the state of a RootSync at a certain point.
+                  description: RootSyncCondition describes the state of a RootSync
+                    at a certain point.
                   properties:
                     commit:
-                      description: hash of the source of truth. It can be a git commit hash, or an OCI image digest.
+                      description: hash of the source of truth. It can be a git commit
+                        hash, or an OCI image digest.
                       type: string
                     errorSourceRefs:
-                      description: errorSourceRefs track the origination(s) of errors when the condition type is Syncing.
+                      description: errorSourceRefs track the origination(s) of errors
+                        when the condition type is Syncing.
                       items:
                         description: ErrorSource indicates the origination of errors.
                         type: string
                       type: array
                     errorSummary:
-                      description: errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled, and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      description: |-
+                        errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled,
+                        and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
                       properties:
                         errorCountAfterTruncation:
-                          description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                          description: errorCountAfterTruncation tracks the number
+                            of errors in the `Errors` field.
                           type: integer
                         totalCount:
                           description: totalCount tracks the total number of errors.
                           type: integer
                         truncated:
-                          description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          description: |-
+                            truncated indicates whether the `Errors` field includes all the errors.
+                            If `true`, the `Errors` field does not includes all the errors.
+                            If `false`, the `Errors` field includes all the errors.
+                            The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                            fail with the `ResourceExhausted` rpc error if there are too many errors.
                           type: boolean
                       type: object
                     errors:
-                      description: errors is a list of errors that occurred in the process. This field is used to track errors when the condition type is Reconciling or Stalled. When the condition type is Syncing, the `errorSourceRefs` field is used instead to avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      description: |-
+                        errors is a list of errors that occurred in the process.
+                        This field is used to track errors when the condition type is Reconciling or Stalled.
+                        When the condition type is Syncing, the `errorSourceRefs` field is used instead to
+                        avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
                       items:
-                        description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                        description: |-
+                          ConfigSyncError represents an error that occurs while parsing, applying, or
+                          remediating a resource.
                         properties:
                           code:
-                            description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                            description: |-
+                              code is the error code of this particular error.  Error codes are numeric strings,
+                              like "1012".
                             type: string
                           errorMessage:
                             description: errorMessage describes the error that occurred.
                             type: string
                           errorResources:
-                            description: errorResources describes the resources associated with this error, if any.
+                            description: errorResources describes the resources associated
+                              with this error, if any.
                             items:
-                              description: ResourceRef contains the identification bits of a single managed resource.
+                              description: ResourceRef contains the identification
+                                bits of a single managed resource.
                               properties:
                                 gvk:
-                                  description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  description: |-
+                                    gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                    empty for errors that are not associated with a specific resource.
                                   properties:
                                     group:
                                       type: string
@@ -325,13 +640,21 @@ spec:
                                   - version
                                   type: object
                                 name:
-                                  description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  description: |-
+                                    name is the name of the affected K8S resource. This field may be empty for
+                                    errors that are not associated with a specific resource.
                                   type: string
                                 namespace:
-                                  description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                  description: |-
+                                    namespace is the namespace of the affected K8S resource. This field may be
+                                    empty for errors that are associated with a cluster-scoped resource or not
+                                    associated with a specific resource.
                                   type: string
                                 sourcePath:
-                                  description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                  description: |-
+                                    sourcePath is the repo-relative slash path to where the config is defined.
+                                    This field may be empty for errors that are not associated with a specific
+                                    config file.
                                   type: string
                               type: object
                             type: array
@@ -341,7 +664,8 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       nullable: true
                       type: string
@@ -351,7 +675,8 @@ spec:
                       nullable: true
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -368,52 +693,79 @@ spec:
                   type: object
                 type: array
               lastSyncedCommit:
-                description: lastSyncedCommit describes the most recent hash that is successfully synced. It can be a git commit hash, or an OCI image digest.
+                description: |-
+                  lastSyncedCommit describes the most recent hash that is successfully synced.
+                  It can be a git commit hash, or an OCI image digest.
                 type: string
               observedGeneration:
-                description: observedGeneration is the most recent generation observed for the sync resource. It corresponds to the it's generation, which is updated on mutation by the API Server.
+                default: 0
+                description: |-
+                  observedGeneration is the most recent generation observed for the sync resource.
+                  It corresponds to the it's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               reconciler:
-                description: reconciler is the name of the reconciler process which corresponds to the sync resource.
+                description: |-
+                  reconciler is the name of the reconciler process which corresponds to the
+                  sync resource.
                 type: string
               rendering:
-                description: rendering contains fields describing the status of rendering resources from the source of truth.
+                description: |-
+                  rendering contains fields describing the status of rendering resources from
+                  the source of truth.
                 properties:
                   commit:
-                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
                     type: string
                   errorSummary:
-                    description: errorSummary summarizes the errors encountered during the process of rendering the source of truth.
+                    description: errorSummary summarizes the errors encountered during
+                      the process of rendering the source of truth.
                     properties:
                       errorCountAfterTruncation:
-                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
                         type: integer
                       totalCount:
                         description: totalCount tracks the total number of errors.
                         type: integer
                       truncated:
-                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
                         type: boolean
                     type: object
                   errors:
-                    description: errors is a list of any errors that occurred while rendering the source of truth.
+                    description: errors is a list of any errors that occurred while
+                      rendering the source of truth.
                     items:
-                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
                       properties:
                         code:
-                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
                           type: string
                         errorMessage:
                           description: errorMessage describes the error that occurred.
                           type: string
                         errorResources:
-                          description: errorResources describes the resources associated with this error, if any.
+                          description: errorResources describes the resources associated
+                            with this error, if any.
                           items:
-                            description: ResourceRef contains the identification bits of a single managed resource.
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
                             properties:
                               gvk:
-                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
                                 properties:
                                   group:
                                     type: string
@@ -427,13 +779,21 @@ spec:
                                 - version
                                 type: object
                               name:
-                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
                                 type: string
                               namespace:
-                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
                                 type: string
                               sourcePath:
-                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
                                 type: string
                             type: object
                           type: array
@@ -443,19 +803,23 @@ spec:
                       type: object
                     type: array
                   gitStatus:
-                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
                     properties:
                       branch:
                         description: branch is the git branch being fetched
                         type: string
                       dir:
-                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
                         type: string
                       repo:
                         description: repo is the git repository URL being synced from.
                         type: string
                       revision:
-                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
                         type: string
                     required:
                     - branch
@@ -463,22 +827,48 @@ spec:
                     - repo
                     - revision
                     type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
                   lastUpdate:
-                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
                     format: date-time
                     nullable: true
                     type: string
                   message:
-                    description: Human-readable message describes details about the rendering status.
+                    description: Human-readable message describes details about the
+                      rendering status.
                     type: string
                   ociStatus:
-                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
                     properties:
                       dir:
-                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
                         type: string
                       image:
-                        description: image is the OCI image repository URL for the package to sync from.
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
                         type: string
                     required:
                     - dir
@@ -486,42 +876,62 @@ spec:
                     type: object
                 type: object
               source:
-                description: source contains fields describing the status of a *Sync's source of truth.
+                description: |-
+                  source contains fields describing the status of a *Sync's source of
+                  truth.
                 properties:
                   commit:
-                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
                     type: string
                   errorSummary:
-                    description: errorSummary summarizes the errors encountered during the process of reading from the source of truth.
+                    description: errorSummary summarizes the errors encountered during
+                      the process of reading from the source of truth.
                     properties:
                       errorCountAfterTruncation:
-                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
                         type: integer
                       totalCount:
                         description: totalCount tracks the total number of errors.
                         type: integer
                       truncated:
-                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
                         type: boolean
                     type: object
                   errors:
-                    description: errors is a list of any errors that occurred while reading from the source of truth.
+                    description: errors is a list of any errors that occurred while
+                      reading from the source of truth.
                     items:
-                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
                       properties:
                         code:
-                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
                           type: string
                         errorMessage:
                           description: errorMessage describes the error that occurred.
                           type: string
                         errorResources:
-                          description: errorResources describes the resources associated with this error, if any.
+                          description: errorResources describes the resources associated
+                            with this error, if any.
                           items:
-                            description: ResourceRef contains the identification bits of a single managed resource.
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
                             properties:
                               gvk:
-                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
                                 properties:
                                   group:
                                     type: string
@@ -535,13 +945,21 @@ spec:
                                 - version
                                 type: object
                               name:
-                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
                                 type: string
                               namespace:
-                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
                                 type: string
                               sourcePath:
-                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
                                 type: string
                             type: object
                           type: array
@@ -551,19 +969,23 @@ spec:
                       type: object
                     type: array
                   gitStatus:
-                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
                     properties:
                       branch:
                         description: branch is the git branch being fetched
                         type: string
                       dir:
-                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
                         type: string
                       repo:
                         description: repo is the git repository URL being synced from.
                         type: string
                       revision:
-                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
                         type: string
                     required:
                     - branch
@@ -571,19 +993,44 @@ spec:
                     - repo
                     - revision
                     type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
                   lastUpdate:
-                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
                     format: date-time
                     nullable: true
                     type: string
                   ociStatus:
-                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
                     properties:
                       dir:
-                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
                         type: string
                       image:
-                        description: image is the OCI image repository URL for the package to sync from.
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
                         type: string
                     required:
                     - dir
@@ -591,42 +1038,63 @@ spec:
                     type: object
                 type: object
               sync:
-                description: sync contains fields describing the status of syncing resources from the source of truth to the cluster.
+                description: |-
+                  sync contains fields describing the status of syncing resources from the
+                  source of truth to the cluster.
                 properties:
                   commit:
-                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
                     type: string
                   errorSummary:
-                    description: errorSummary summarizes the errors encountered during the process of syncing the resources.
+                    description: errorSummary summarizes the errors encountered during
+                      the process of syncing the resources.
                     properties:
                       errorCountAfterTruncation:
-                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
                         type: integer
                       totalCount:
                         description: totalCount tracks the total number of errors.
                         type: integer
                       truncated:
-                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
                         type: boolean
                     type: object
                   errors:
-                    description: errors is a list of any errors that occurred while applying the resources from the change indicated by Commit.
+                    description: |-
+                      errors is a list of any errors that occurred while applying the resources
+                      from the change indicated by Commit.
                     items:
-                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
                       properties:
                         code:
-                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
                           type: string
                         errorMessage:
                           description: errorMessage describes the error that occurred.
                           type: string
                         errorResources:
-                          description: errorResources describes the resources associated with this error, if any.
+                          description: errorResources describes the resources associated
+                            with this error, if any.
                           items:
-                            description: ResourceRef contains the identification bits of a single managed resource.
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
                             properties:
                               gvk:
-                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
                                 properties:
                                   group:
                                     type: string
@@ -640,13 +1108,21 @@ spec:
                                 - version
                                 type: object
                               name:
-                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
                                 type: string
                               namespace:
-                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
                                 type: string
                               sourcePath:
-                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
                                 type: string
                             type: object
                           type: array
@@ -656,19 +1132,23 @@ spec:
                       type: object
                     type: array
                   gitStatus:
-                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
                     properties:
                       branch:
                         description: branch is the git branch being fetched
                         type: string
                       dir:
-                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
                         type: string
                       repo:
                         description: repo is the git repository URL being synced from.
                         type: string
                       revision:
-                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
                         type: string
                     required:
                     - branch
@@ -676,19 +1156,44 @@ spec:
                     - repo
                     - revision
                     type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
                   lastUpdate:
-                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
                     format: date-time
                     nullable: true
                     type: string
                   ociStatus:
-                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
                     properties:
                       dir:
-                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
                         type: string
                       image:
-                        description: image is the OCI image repository URL for the package to sync from.
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
                         type: string
                     required:
                     - dir
@@ -726,10 +1231,19 @@ spec:
         description: RootSync is the Schema for the rootsyncs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -737,10 +1251,14 @@ spec:
             description: RootSyncSpec defines the desired state of RootSync
             properties:
               git:
-                description: git contains configuration specific to importing resources from a Git repo.
+                description: git contains configuration specific to importing resources
+                  from a Git repo.
                 properties:
                   auth:
-                    description: auth is the type of secret configured for access to the Git repo. Must be one of ssh, cookiefile, gcenode, token, or none. The validation of this is case-sensitive. Required.
+                    description: |-
+                      auth is the type of secret configured for access to the Git repo.
+                      Must be one of ssh, cookiefile, gcenode, token, or none.
+                      The validation of this is case-sensitive. Required.
                     enum:
                     - ssh
                     - cookiefile
@@ -750,31 +1268,74 @@ spec:
                     - none
                     type: string
                   branch:
-                    description: 'branch is the git branch to checkout. Default: "master".'
+                    description: |-
+                      branch is the git branch to sync from.
+                      Branch defaults to 'master', but if 'revision' is set and is not 'HEAD',
+                      'revision' takes precedence over 'branch'.
                     type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   dir:
-                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the repo.'
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the repo.
                     type: string
                   gcpServiceAccountEmail:
-                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
                     type: string
                   noSSLVerify:
-                    description: 'noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false. If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.'
+                    description: |-
+                      noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false.
+                      If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.
+                      This should either be false or unset when caCertSecretRef is provided.
                     type: boolean
                   period:
-                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
                     type: string
                   proxy:
-                    description: proxy specifies an HTTPS proxy for accessing the Git repo. Only has an effect when secretType is one of ("cookiefile", "none", "token"). When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information such as a username or password and you need to hide the sensitive information, you can leave this field empty and add the URL for the HTTPS proxy into the same Secret used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    description: |-
+                      proxy specifies an HTTPS proxy for accessing the Git repo.
+                      Only has an effect when secretType is one of ("cookiefile", "none", "token").
+                      When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information
+                      such as a username or password and you need to hide the sensitive information,
+                      you can leave this field empty and add the URL for the HTTPS proxy into the same Secret
+                      used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
                     type: string
                   repo:
                     description: repo is the git repository URL to sync from. Required.
                     type: string
                   revision:
-                    description: 'revision is the git revision (tag, ref or commit) to fetch. Default: "HEAD".'
+                    description: |-
+                      revision is the git revision (branch, tag, ref or commit) to fetch.
+                      If 'revision' is not specified, it defaults to the HEAD of the branch that
+                      is specified in the 'branch' field.
+                      If neither 'revision' nor 'branch' is specified, it defaults to the HEAD of
+                      the 'master' branch.
                     type: string
                   secretRef:
-                    description: secretRef is the secret used to connect to the Git source of truth.
+                    description: secretRef is the secret used to connect to the Git
+                      source of truth.
+                    nullable: true
                     properties:
                       name:
                         description: name represents the secret name.
@@ -785,29 +1346,71 @@ spec:
                 - repo
                 type: object
               helm:
-                description: helm contains configuration specific to importing resources from a Helm repo.
+                description: helm contains configuration specific to importing resources
+                  from a Helm repo.
                 properties:
                   auth:
-                    description: auth specifies the type to authenticate to the Helm repository. Must be one of secret, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    description: |-
+                      auth specifies the type to authenticate to the Helm repository.
+                      Must be one of token, gcpserviceaccount, k8sserviceaccount, gcenode or none.
+                      The validation of this is case-sensitive. Required.
                     enum:
                     - none
                     - gcpserviceaccount
+                    - k8sserviceaccount
                     - token
+                    - gcenode
                     type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   chart:
                     description: chart is a Helm chart name. Required.
                     type: string
+                  deployNamespace:
+                    description: |-
+                      deployNamespace specifies the namespace in which to deploy the chart.
+                      This is a mutually exclusive setting with "namespace".
+                      If neither namespace nor deployNamespace are set, the chart will be
+                      deployed into the default namespace.
+                    type: string
                   gcpServiceAccountEmail:
-                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when spec.helm.auth: gcpserviceaccount.'
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when spec.helm.auth: gcpserviceaccount.
                     type: string
                   includeCRDs:
-                    description: 'includeCRDs specifies if Helm template should also generate CustomResourceDefinitions. If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated. Default: false.'
+                    description: |-
+                      includeCRDs specifies if Helm template should also generate CustomResourceDefinitions.
+                      If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated.
+                      Default: false.
                     type: boolean
                   namespace:
-                    description: namespace sets the target namespace for a release
+                    description: |-
+                      namespace sets the value of {{Release.Namespace}} defined in the chart templates.
+                      This is a mutually exclusive setting with "deployNamespace".
+                      Default: default.
                     type: string
                   period:
-                    description: 'period is the time duration between consecutive syncs. Default: 15s. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Chart will not be re-synced if version is specified and it is not "latest"'
+                    description: |-
+                      period is the time duration that Config Sync waits before refetching the chart.
+                      Default: 1 hour.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      If the chart version is a range, the literal tag "latest", or left empty to indicate that Config Sync
+                      should fetch the latest version, the chart will be re-fetched according to spec.helm.period.
+                      If the chart version is specified as a single static version, the chart will not be re-fetched.
                     type: string
                   releaseName:
                     description: releaseName is the name of the Helm release.
@@ -816,22 +1419,53 @@ spec:
                     description: repo is the helm repository URL to sync from. Required.
                     type: string
                   secretRef:
-                    description: secretRef holds the authentication secret for accessing the Helm repository.
+                    description: |-
+                      secretRef holds the authentication secret for accessing
+                      the Helm repository.
+                    nullable: true
                     properties:
                       name:
                         description: name represents the secret name.
                         type: string
                     type: object
                   values:
-                    description: values to use instead of default values that accompany the chart
-                    type: object
-                  valuesFiles:
-                    description: valuesFiles is a list of path to Helm value files. Values files must be in the same repository with the Helm chart. And the paths here are absolute path from the root directory of the repository
+                    description: |-
+                      values to use instead of default values that accompany the chart. Format
+                      values the same as default values.yaml. If `valuesFileRefs` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
+                    x-kubernetes-preserve-unknown-fields: true
+                  valuesFileRefs:
+                    description: |-
+                      valuesFileRefs holds references to objects in the cluster that represent
+                      values to use instead of default values that accompany the chart. Currently,
+                      only ConfigMaps are supported. The ConfigMaps must be immutable and in the same
+                      namespace as the RootSync/RepoSync. When multiple values files are specified, duplicated
+                      keys in later files will override the value from earlier files. This is equivalent
+                      to passing in multiple values files to Helm CLI. If `values` is also specified,
+                      fields from `values` will override fields from `valuesFileRefs`.
                     items:
-                      type: string
+                      description: |-
+                        ValuesFileRef references a ConfigMap object that contains a values file to use for
+                        helm rendering. The ConfigMap must be in the same namespace as the RootSync/RepoSync.
+                      properties:
+                        dataKey:
+                          description: 'dataKey represents the object data key to
+                            read the values from. Default: `values.yaml`'
+                          type: string
+                        name:
+                          description: name represents the Object name. Required.
+                          type: string
+                      type: object
                     type: array
                   version:
-                    description: version is the chart version. If this is not specified, the latest version is used
+                    description: |-
+                      version is the chart version.
+                      This can be specified as a static version, or as a range of values from which Config Sync
+                      will fetch the latest. If left empty, Config Sync will fetch the latest version according to semver.
+                      The supported version range syntax is identical to the version range syntax
+                      supported by helm CLI, and is documented here: https://github.com/Masterminds/semver#hyphen-range-comparisons.
+                      Versions specified as a range, the literal tag "latest", or left empty to indicate that Config Sync should
+                      fetch the latest version, will be fetched every sync according to spec.helm.period.
                     type: string
                 required:
                 - auth
@@ -839,26 +1473,62 @@ spec:
                 - repo
                 type: object
               oci:
-                description: oci contains configuration specific to importing resources from an OCI package.
+                description: oci contains configuration specific to importing resources
+                  from an OCI package.
                 properties:
                   auth:
-                    description: auth is the type of secret configured for access to the OCI package. Must be one of gcenode, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    description: |-
+                      auth is the type of secret configured for access to the OCI package.
+                      Must be one of gcenode, gcpserviceaccount, k8sserviceaccount, or none.
+                      The validation of this is case-sensitive. Required.
                     enum:
                     - gcenode
                     - gcpserviceaccount
+                    - k8sserviceaccount
                     - none
                     type: string
+                  caCertSecretRef:
+                    description: |-
+                      caCertSecretRef specifies the name of the secret where the CA certificate is stored.
+                      The creation of the secret should be done out of band by the user and should store the
+                      certificate in a key named "cert". For RepoSync resources, the secret must be
+                      created in the same namespace as the RepoSync. For RootSync resource, the secret
+                      must be created in the config-management-system namespace.
+                    nullable: true
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
                   dir:
-                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the image.'
+                    description: |-
+                      dir is the absolute path of the directory that contains
+                      the local resources.  Default: the root directory of the image.
                     type: string
                   gcpServiceAccountEmail:
-                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    description: |-
+                      gcpServiceAccountEmail specifies the GCP service account used to annotate
+                      the RootSync/RepoSync controller Kubernetes Service Account.
+                      Note: The field is used when secretType: gcpServiceAccount.
                     type: string
                   image:
-                    description: 'image is the OCI image repository URL for the package to sync from. e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`. The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME. - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`. - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`. If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default. Required'
+                    description: |-
+                      image is the OCI image repository URL for the package to sync from.
+                      e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`.
+                      The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME.
+                      - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`.
+                      - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`.
+                      If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default.
+                      Required
                     type: string
                   period:
-                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    description: |-
+                      period is the time duration between consecutive syncs. Default: 15s.
+                      Note to developers that customers specify this value using
+                      string (https://golang.org/pkg/time/#Duration.String) like "3s"
+                      in their Custom Resource YAML. However, time.Duration is at a nanosecond
+                      granularity, and it is easy to introduce a bug where it looks like the
+                      code is dealing with seconds but its actually nanoseconds (or vice versa).
                     type: string
                 required:
                 - auth
@@ -868,68 +1538,195 @@ spec:
                 description: override allows to override the settings for a root reconciler.
                 nullable: true
                 properties:
+                  apiServerTimeout:
+                    description: |-
+                      apiServerTimeout allows one to override the client-side timeout for requests to the API server.
+                      Default: 15s.
+                      Use string to specify this field value, like "30s", "1m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended apiServerTimeout range is from "3s" to "1m".
+                    type: string
                   enableShellInRendering:
-                    description: 'enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false. Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and support pulling remote bases from public repositories.'
+                    description: |-
+                      enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false.
+                      Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and
+                      support pulling remote bases from public repositories.
                     type: boolean
                   gitSyncDepth:
-                    description: gitSyncDepth allows one to override the number of git commits to fetch. Must be no less than 0. Config Sync would do a full clone if this field is 0, and a shallow clone if this field is greater than 0. If this field is not provided, Config Sync would configure it automatically.
+                    description: |-
+                      gitSyncDepth allows one to override the number of git commits to fetch.
+                      Must be no less than 0.
+                      Config Sync would do a full clone if this field is 0, and a shallow
+                      clone if this field is greater than 0.
+                      If this field is not provided, Config Sync would configure it automatically.
                     format: int64
                     minimum: 0
                     type: integer
-                  reconcileTimeout:
-                    description: 'reconcileTimeout allows one to override the threshold for how long to wait for all resources to reconcile before giving up. Default: 5m. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended reconcileTimeout range is from "10s" to "1h".'
-                    type: string
-                  resources:
-                    description: resources allow one to override the resource requirements for the containers in a reconciler pod.
+                  logLevels:
+                    description: |-
+                      logLevels specify the container name and log level override value for the reconciler deployment container.
+                      Each entry must contain the name of the reconciler deployment container and the desired log level.
                     items:
-                      description: ContainerResourcesSpec allows to override the resource requirements for a container
+                      description: ContainerLogLevelOverride specifies the container
+                        name and log level override value
                       properties:
                         containerName:
-                          description: containerName specifies the name of a container whose resource requirements will be overridden. Must be "reconciler", "git-sync", "hydration-controller", or "oci-sync".
-                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync)$
+                          description: |-
+                            containerName specifies the name of the reconciler deployment container for which log level will be overridden.
+                            Must be one of the following: "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
+                          type: string
+                        logLevel:
+                          description: |-
+                            logLevel specifies the verbosity level of the logging for a specific container.
+                            The "git-sync" and "otel-agent" containers default to 5, while all other containers default to 0.
+                            Increasing the value of logLevel increases the verbosity of the logs.
+                            Lower severity messages are logged at higher verbosity.
+                            Allowed values are from 0 to 10.
+                          maximum: 10
+                          minimum: 0
+                          type: integer
+                      required:
+                      - containerName
+                      - logLevel
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerName
+                    x-kubernetes-list-type: map
+                  namespaceStrategy:
+                    description: |-
+                      namespaceStrategy controls how the reconciler handles Namespaces
+                      which are used by resources in the source but not declared. Only applies
+                      when using the unstructured sourceFormat.
+                      Must be "implicit" or "explicit". Default: "implicit".
+                      "implicit" means that the reconciler will implicitly create Namespaces
+                      if they do not exist, even if they are not declared in the source.
+                      "explicit" means that the reconciler will not create Namespaces which
+                      are not declared in the source.
+                    enum:
+                    - implicit
+                    - explicit
+                    type: string
+                  reconcileTimeout:
+                    description: |-
+                      reconcileTimeout allows one to override the threshold for how long to wait for
+                      all resources to reconcile before giving up.
+                      Default: 5m.
+                      Use string to specify this field value, like "30s", "5m".
+                      More details about valid inputs: https://pkg.go.dev/time#ParseDuration.
+                      Recommended reconcileTimeout range is from "10s" to "1h".
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements
+                      for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource
+                        requirements for a container
+                      properties:
+                        containerName:
+                          description: |-
+                            containerName specifies the name of a container whose resource requirements will be overridden.
+                            Must be "reconciler", "git-sync", "hydration-controller", "oci-sync", or "helm-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync|helm-sync|gcenode-askpass-sidecar|otel-agent)$
                           type: string
                         cpuLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: cpuLimit allows one to override the CPU limit of a container
+                          description: cpuLimit allows one to override the CPU limit
+                            of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         cpuRequest:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: cpuRequest allows one to override the CPU request of a container
+                          description: cpuRequest allows one to override the CPU request
+                            of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         memoryLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: memoryLimit allows one to override the memory limit of a container
+                          description: memoryLimit allows one to override the memory
+                            limit of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         memoryRequest:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: memoryRequest allows one to override the memory request of a container
+                          description: memoryRequest allows one to override the memory
+                            request of a container
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     type: array
+                  roleRefs:
+                    description: |-
+                      roleRefs is a list of Roles or ClusterRoles to create bindings.
+                      If unset, a binding to cluster-admin will be created.
+                    items:
+                      description: |-
+                        each item references a Role or ClusterRole to create
+                        a binding to for this reconciler. It supports a namespace field that can be used
+                        to create RoleBindings rather than ClusterRoleBindings.
+                      properties:
+                        kind:
+                          description: |-
+                            kind refers to the Kind of the RBAC resource.
+                            Accepted values are Role and ClusterRole. Required.
+                          enum:
+                          - Role
+                          - ClusterRole
+                          type: string
+                        name:
+                          description: name is the name of the Role or ClusterRole
+                            resource. Required.
+                          type: string
+                        namespace:
+                          description: |-
+                            namespace indicates the Namespace in which a RoleBinding should be created.
+                            For ClusterRole objects, will determine whether a RoleBinding or ClusterRoleBinding
+                            is created.
+                            For Role objects, must be set to the same namespace as the Role.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
                   statusMode:
-                    description: statusMode controls whether the actuation status such as apply failed or not should be embedded into the ResourceGroup object. Must be "enabled" or "disabled". If set to "enabled", it increases the size of the ResourceGroup object.
+                    description: |-
+                      statusMode controls whether the actuation status
+                      such as apply failed or not should be embedded into the ResourceGroup object.
+                      Must be "enabled" or "disabled".
+                      If set to "enabled", it increases the size of the ResourceGroup object.
                     pattern: ^(enabled|disabled|)$
                     type: string
                 type: object
               sourceFormat:
-                description: "sourceFormat specifies how the repository is formatted. See documentation for specifics of what these options do. \n Must be one of hierarchy, unstructured. Optional. Set to hierarchy if not specified. \n The validation of this is case-sensitive."
+                description: |-
+                  sourceFormat specifies how the repository is formatted.
+                  See documentation for specifics of what these options do.
+
+
+                  Must be one of hierarchy, unstructured. Optional. Set to
+                  hierarchy if not specified.
+
+
+                  The validation of this is case-sensitive.
                 pattern: ^(hierarchy|unstructured|)$
                 type: string
               sourceType:
                 default: git
-                description: "sourceType specifies the type of the source of truth. \n Must be one of git, oci, helm. Optional. Set to git if not specified."
+                description: |-
+                  sourceType specifies the type of the source of truth.
+
+
+                  Must be one of git, oci, helm. Optional. Set to git if not specified.
                 pattern: ^(git|oci|helm)$
                 type: string
             type: object
@@ -937,50 +1734,75 @@ spec:
             description: RootSyncStatus defines the observed state of RootSync
             properties:
               conditions:
-                description: conditions represents the latest available observations of the RootSync's current state.
+                description: |-
+                  conditions represents the latest available observations of the RootSync's
+                  current state.
                 items:
-                  description: RootSyncCondition describes the state of a RootSync at a certain point.
+                  description: RootSyncCondition describes the state of a RootSync
+                    at a certain point.
                   properties:
                     commit:
-                      description: hash of the source of truth. It can be a git commit hash, or an OCI image digest.
+                      description: hash of the source of truth. It can be a git commit
+                        hash, or an OCI image digest.
                       type: string
                     errorSourceRefs:
-                      description: errorSourceRefs track the origination(s) of errors when the condition type is Syncing.
+                      description: errorSourceRefs track the origination(s) of errors
+                        when the condition type is Syncing.
                       items:
                         description: ErrorSource indicates the origination of errors.
                         type: string
                       type: array
                     errorSummary:
-                      description: errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled, and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      description: |-
+                        errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled,
+                        and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
                       properties:
                         errorCountAfterTruncation:
-                          description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                          description: errorCountAfterTruncation tracks the number
+                            of errors in the `Errors` field.
                           type: integer
                         totalCount:
                           description: totalCount tracks the total number of errors.
                           type: integer
                         truncated:
-                          description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          description: |-
+                            truncated indicates whether the `Errors` field includes all the errors.
+                            If `true`, the `Errors` field does not includes all the errors.
+                            If `false`, the `Errors` field includes all the errors.
+                            The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                            fail with the `ResourceExhausted` rpc error if there are too many errors.
                           type: boolean
                       type: object
                     errors:
-                      description: errors is a list of errors that occurred in the process. This field is used to track errors when the condition type is Reconciling or Stalled. When the condition type is Syncing, the `errorSourceRefs` field is used instead to avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      description: |-
+                        errors is a list of errors that occurred in the process.
+                        This field is used to track errors when the condition type is Reconciling or Stalled.
+                        When the condition type is Syncing, the `errorSourceRefs` field is used instead to
+                        avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
                       items:
-                        description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                        description: |-
+                          ConfigSyncError represents an error that occurs while parsing, applying, or
+                          remediating a resource.
                         properties:
                           code:
-                            description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                            description: |-
+                              code is the error code of this particular error.  Error codes are numeric strings,
+                              like "1012".
                             type: string
                           errorMessage:
                             description: errorMessage describes the error that occurred.
                             type: string
                           errorResources:
-                            description: errorResources describes the resources associated with this error, if any.
+                            description: errorResources describes the resources associated
+                              with this error, if any.
                             items:
-                              description: ResourceRef contains the identification bits of a single managed resource.
+                              description: ResourceRef contains the identification
+                                bits of a single managed resource.
                               properties:
                                 gvk:
-                                  description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  description: |-
+                                    gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                    empty for errors that are not associated with a specific resource.
                                   properties:
                                     group:
                                       type: string
@@ -994,13 +1816,21 @@ spec:
                                   - version
                                   type: object
                                 name:
-                                  description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  description: |-
+                                    name is the name of the affected K8S resource. This field may be empty for
+                                    errors that are not associated with a specific resource.
                                   type: string
                                 namespace:
-                                  description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                  description: |-
+                                    namespace is the namespace of the affected K8S resource. This field may be
+                                    empty for errors that are associated with a cluster-scoped resource or not
+                                    associated with a specific resource.
                                   type: string
                                 sourcePath:
-                                  description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                  description: |-
+                                    sourcePath is the repo-relative slash path to where the config is defined.
+                                    This field may be empty for errors that are not associated with a specific
+                                    config file.
                                   type: string
                               type: object
                             type: array
@@ -1010,7 +1840,8 @@ spec:
                         type: object
                       type: array
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       nullable: true
                       type: string
@@ -1020,7 +1851,8 @@ spec:
                       nullable: true
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -1037,52 +1869,79 @@ spec:
                   type: object
                 type: array
               lastSyncedCommit:
-                description: lastSyncedCommit describes the most recent hash that is successfully synced. It can be a git commit hash, or an OCI image digest.
+                description: |-
+                  lastSyncedCommit describes the most recent hash that is successfully synced.
+                  It can be a git commit hash, or an OCI image digest.
                 type: string
               observedGeneration:
-                description: observedGeneration is the most recent generation observed for the sync resource. It corresponds to the it's generation, which is updated on mutation by the API Server.
+                default: 0
+                description: |-
+                  observedGeneration is the most recent generation observed for the sync resource.
+                  It corresponds to the it's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               reconciler:
-                description: reconciler is the name of the reconciler process which corresponds to the sync resource.
+                description: |-
+                  reconciler is the name of the reconciler process which corresponds to the
+                  sync resource.
                 type: string
               rendering:
-                description: rendering contains fields describing the status of rendering resources from the source of truth.
+                description: |-
+                  rendering contains fields describing the status of rendering resources from
+                  the source of truth.
                 properties:
                   commit:
-                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
                     type: string
                   errorSummary:
-                    description: errorSummary summarizes the errors encountered during the process of rendering the source of truth.
+                    description: errorSummary summarizes the errors encountered during
+                      the process of rendering the source of truth.
                     properties:
                       errorCountAfterTruncation:
-                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
                         type: integer
                       totalCount:
                         description: totalCount tracks the total number of errors.
                         type: integer
                       truncated:
-                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
                         type: boolean
                     type: object
                   errors:
-                    description: errors is a list of any errors that occurred while rendering the source of truth.
+                    description: errors is a list of any errors that occurred while
+                      rendering the source of truth.
                     items:
-                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
                       properties:
                         code:
-                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
                           type: string
                         errorMessage:
                           description: errorMessage describes the error that occurred.
                           type: string
                         errorResources:
-                          description: errorResources describes the resources associated with this error, if any.
+                          description: errorResources describes the resources associated
+                            with this error, if any.
                           items:
-                            description: ResourceRef contains the identification bits of a single managed resource.
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
                             properties:
                               gvk:
-                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
                                 properties:
                                   group:
                                     type: string
@@ -1096,13 +1955,21 @@ spec:
                                 - version
                                 type: object
                               name:
-                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
                                 type: string
                               namespace:
-                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
                                 type: string
                               sourcePath:
-                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
                                 type: string
                             type: object
                           type: array
@@ -1112,19 +1979,23 @@ spec:
                       type: object
                     type: array
                   gitStatus:
-                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
                     properties:
                       branch:
                         description: branch is the git branch being fetched
                         type: string
                       dir:
-                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
                         type: string
                       repo:
                         description: repo is the git repository URL being synced from.
                         type: string
                       revision:
-                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
                         type: string
                     required:
                     - branch
@@ -1132,22 +2003,48 @@ spec:
                     - repo
                     - revision
                     type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
                   lastUpdate:
-                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
                     format: date-time
                     nullable: true
                     type: string
                   message:
-                    description: Human-readable message describes details about the rendering status.
+                    description: Human-readable message describes details about the
+                      rendering status.
                     type: string
                   ociStatus:
-                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
                     properties:
                       dir:
-                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
                         type: string
                       image:
-                        description: image is the OCI image repository URL for the package to sync from.
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
                         type: string
                     required:
                     - dir
@@ -1155,42 +2052,62 @@ spec:
                     type: object
                 type: object
               source:
-                description: source contains fields describing the status of a *Sync's source of truth.
+                description: |-
+                  source contains fields describing the status of a *Sync's source of
+                  truth.
                 properties:
                   commit:
-                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
                     type: string
                   errorSummary:
-                    description: errorSummary summarizes the errors encountered during the process of reading from the source of truth.
+                    description: errorSummary summarizes the errors encountered during
+                      the process of reading from the source of truth.
                     properties:
                       errorCountAfterTruncation:
-                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
                         type: integer
                       totalCount:
                         description: totalCount tracks the total number of errors.
                         type: integer
                       truncated:
-                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
                         type: boolean
                     type: object
                   errors:
-                    description: errors is a list of any errors that occurred while reading from the source of truth.
+                    description: errors is a list of any errors that occurred while
+                      reading from the source of truth.
                     items:
-                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
                       properties:
                         code:
-                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
                           type: string
                         errorMessage:
                           description: errorMessage describes the error that occurred.
                           type: string
                         errorResources:
-                          description: errorResources describes the resources associated with this error, if any.
+                          description: errorResources describes the resources associated
+                            with this error, if any.
                           items:
-                            description: ResourceRef contains the identification bits of a single managed resource.
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
                             properties:
                               gvk:
-                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
                                 properties:
                                   group:
                                     type: string
@@ -1204,13 +2121,21 @@ spec:
                                 - version
                                 type: object
                               name:
-                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
                                 type: string
                               namespace:
-                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
                                 type: string
                               sourcePath:
-                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
                                 type: string
                             type: object
                           type: array
@@ -1220,19 +2145,23 @@ spec:
                       type: object
                     type: array
                   gitStatus:
-                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
                     properties:
                       branch:
                         description: branch is the git branch being fetched
                         type: string
                       dir:
-                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
                         type: string
                       repo:
                         description: repo is the git repository URL being synced from.
                         type: string
                       revision:
-                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
                         type: string
                     required:
                     - branch
@@ -1240,19 +2169,44 @@ spec:
                     - repo
                     - revision
                     type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
                   lastUpdate:
-                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
                     format: date-time
                     nullable: true
                     type: string
                   ociStatus:
-                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
                     properties:
                       dir:
-                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
                         type: string
                       image:
-                        description: image is the OCI image repository URL for the package to sync from.
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
                         type: string
                     required:
                     - dir
@@ -1260,42 +2214,63 @@ spec:
                     type: object
                 type: object
               sync:
-                description: sync contains fields describing the status of syncing resources from the source of truth to the cluster.
+                description: |-
+                  sync contains fields describing the status of syncing resources from the
+                  source of truth to the cluster.
                 properties:
                   commit:
-                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    description: |-
+                      hash of the source of truth that is rendered.
+                      It can be a git commit hash, or an OCI image digest.
                     type: string
                   errorSummary:
-                    description: errorSummary summarizes the errors encountered during the process of syncing the resources.
+                    description: errorSummary summarizes the errors encountered during
+                      the process of syncing the resources.
                     properties:
                       errorCountAfterTruncation:
-                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        description: errorCountAfterTruncation tracks the number of
+                          errors in the `Errors` field.
                         type: integer
                       totalCount:
                         description: totalCount tracks the total number of errors.
                         type: integer
                       truncated:
-                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        description: |-
+                          truncated indicates whether the `Errors` field includes all the errors.
+                          If `true`, the `Errors` field does not includes all the errors.
+                          If `false`, the `Errors` field includes all the errors.
+                          The size limit of a RootSync/RepoSync object is 2MiB. The status update would
+                          fail with the `ResourceExhausted` rpc error if there are too many errors.
                         type: boolean
                     type: object
                   errors:
-                    description: errors is a list of any errors that occurred while applying the resources from the change indicated by Commit.
+                    description: |-
+                      errors is a list of any errors that occurred while applying the resources
+                      from the change indicated by Commit.
                     items:
-                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      description: |-
+                        ConfigSyncError represents an error that occurs while parsing, applying, or
+                        remediating a resource.
                       properties:
                         code:
-                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          description: |-
+                            code is the error code of this particular error.  Error codes are numeric strings,
+                            like "1012".
                           type: string
                         errorMessage:
                           description: errorMessage describes the error that occurred.
                           type: string
                         errorResources:
-                          description: errorResources describes the resources associated with this error, if any.
+                          description: errorResources describes the resources associated
+                            with this error, if any.
                           items:
-                            description: ResourceRef contains the identification bits of a single managed resource.
+                            description: ResourceRef contains the identification bits
+                              of a single managed resource.
                             properties:
                               gvk:
-                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  gvk is the GroupVersionKind of the affected K8S resource. This field may be
+                                  empty for errors that are not associated with a specific resource.
                                 properties:
                                   group:
                                     type: string
@@ -1309,13 +2284,21 @@ spec:
                                 - version
                                 type: object
                               name:
-                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                description: |-
+                                  name is the name of the affected K8S resource. This field may be empty for
+                                  errors that are not associated with a specific resource.
                                 type: string
                               namespace:
-                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                description: |-
+                                  namespace is the namespace of the affected K8S resource. This field may be
+                                  empty for errors that are associated with a cluster-scoped resource or not
+                                  associated with a specific resource.
                                 type: string
                               sourcePath:
-                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                description: |-
+                                  sourcePath is the repo-relative slash path to where the config is defined.
+                                  This field may be empty for errors that are not associated with a specific
+                                  config file.
                                 type: string
                             type: object
                           type: array
@@ -1325,19 +2308,23 @@ spec:
                       type: object
                     type: array
                   gitStatus:
-                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    description: gitStatus contains fields describing the status of
+                      a Git source of truth.
                     properties:
                       branch:
                         description: branch is the git branch being fetched
                         type: string
                       dir:
-                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        description: |-
+                          dir is the path within the Git repository that represents the top level of the repo to sync.
+                          Default: the root directory of the repository
                         type: string
                       repo:
                         description: repo is the git repository URL being synced from.
                         type: string
                       revision:
-                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        description: revision is the git revision (tag, ref, or commit)
+                          being fetched.
                         type: string
                     required:
                     - branch
@@ -1345,19 +2332,44 @@ spec:
                     - repo
                     - revision
                     type: object
+                  helmStatus:
+                    description: helmStatus contains fields describing the status
+                      of a Helm source of truth.
+                    properties:
+                      chart:
+                        description: chart is the name of helm chart being fetched
+                        type: string
+                      repo:
+                        description: repo is the helm repository URL being synced
+                          from.
+                        type: string
+                      version:
+                        description: version is the helm chart version being fetched.
+                        type: string
+                    required:
+                    - chart
+                    - repo
+                    - version
+                    type: object
                   lastUpdate:
-                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    description: |-
+                      lastUpdate is the timestamp of when this status was last updated by a
+                      reconciler.
                     format: date-time
                     nullable: true
                     type: string
                   ociStatus:
-                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    description: ociStatus contains fields describing the status of
+                      an OCI source of truth.
                     properties:
                       dir:
-                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        description: |-
+                          dir is the absolute path of the directory that contains the local resources.
+                          Default: the root directory of the repository
                         type: string
                       image:
-                        description: image is the OCI image repository URL for the package to sync from.
+                        description: image is the OCI image repository URL for the
+                          package to sync from.
                         type: string
                     required:
                     - dir

--- a/nephio/optional/rootsync/rootsync.yaml
+++ b/nephio/optional/rootsync/rootsync.yaml
@@ -11,3 +11,4 @@ spec:
     auth: token
     secretRef:
       name: example-cluster-name-access-token-configsync
+    period: 15s


### PR DESCRIPTION
https://github.com/nephio-project/nephio/issues/800

The addition of the git.period value in the RootSync resource was added to assess a better value for this.
https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/reference/rootsync-reposync-fields#configuring-git-repo

The default value is unchanged at 15 sec.