### PR TITLE
Adding Security Context Constraints for OCP (to main)

### DIFF
--- a/distros/openshift/security-context-constraints/README.md
+++ b/distros/openshift/security-context-constraints/README.md
@@ -1,0 +1,9 @@
+# distros/openshift/security-context-constraints
+
+## Security Context Constraints
+
+OpenShift deployments require Security Context Constraints to be applied for containers to function properly. The ones defined here were identified through testing the deployment against an OpenShift cluster and creating SCCs. These are prerequisites, and should be applied before attempting to install Nephio components.
+
+## Storage
+
+Gitea requires storage to be configured on the OpenShift cluster. Whether LVM, Local Storage, etc. there needs to be storage and a default Storage Class for the Persistent Volumes to be allocated.

--- a/distros/openshift/security-context-constraints/scc-admin-metallb-system-controller.yaml
+++ b/distros/openshift/security-context-constraints/scc-admin-metallb-system-controller.yaml
@@ -1,0 +1,23 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-admin-metallb-system-controller
+allowPrivilegeEscalation: false
+groups:
+- system:cluster-admins
+- system:nodes
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 65534
+      max: 65534
+readOnlyRootFilesystem: true
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: MustRunAsNonRoot
+  uid: 65534
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:metallb-system:controller

--- a/distros/openshift/security-context-constraints/scc-admin-metallb-system-speaker.yaml
+++ b/distros/openshift/security-context-constraints/scc-admin-metallb-system-speaker.yaml
@@ -1,0 +1,23 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-admin-metallb-system-speaker
+allowHostNetwork: true
+allowHostPorts: true
+allowPrivilegeEscalation: false
+allowedCapabilities:
+- NET_RAW
+groups:
+- system:cluster-admins
+- system:nodes
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: true
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:metallb-system:speaker

--- a/distros/openshift/security-context-constraints/scc-capd-system-capd-manager.yaml
+++ b/distros/openshift/security-context-constraints/scc-capd-system-capd-manager.yaml
@@ -1,0 +1,15 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-capd-system-capd-manager
+allowHostDirVolumePlugin: true
+allowPrivilegedContainer: true
+groups:
+- system:cluster-admins
+- system:nodes
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:capd-system:capd-manager

--- a/distros/openshift/security-context-constraints/scc-capi-system-capi-manager.yaml
+++ b/distros/openshift/security-context-constraints/scc-capi-system-capi-manager.yaml
@@ -1,0 +1,28 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-capi-system-capi-manager
+allowPrivilegeEscalation: false
+groups:
+- system:cluster-admins
+- system:nodes
+fsGroup:
+  ranges:
+    - min: 65532
+      max: 65532 
+  type: MustRunAs
+requiredDropCapabilities:
+  - ALL
+runAsUser: 
+  uid: 65532
+  type: MustRunAsNonRoot
+    #seccompProfile:
+    #  type: RuntimeDefault
+seccompProfiles:
+- runtime/default
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:capi-system:capi-manager
+- system:serviceaccount:capi-kubeadm-bootstrap-system:capi-kubeadm-bootstrap-manager
+- system:serviceaccount:capi-kubeadm-control-plane-system:capi-kubeadm-control-plane-manager

--- a/distros/openshift/security-context-constraints/scc-config-management-monitoring-default.yaml
+++ b/distros/openshift/security-context-constraints/scc-config-management-monitoring-default.yaml
@@ -1,0 +1,21 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: true
+metadata:
+  name: scc-config-management-monitoring-default
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 2000
+      max: 2000
+groups:
+- system:cluster-admins
+- system:nodes
+runAsUser:
+  type: MustRunAsNonRoot
+  uid: 1000
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:config-management-monitoring:default

--- a/distros/openshift/security-context-constraints/scc-gitea-memcached-default.yaml
+++ b/distros/openshift/security-context-constraints/scc-gitea-memcached-default.yaml
@@ -1,0 +1,20 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-gitea-memcached-default
+allowPrivilegeEscalation: false
+groups:
+- system:cluster-admins
+- system:nodes
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 1001
+      max: 1001
+runAsUser:
+  type: MustRunAsNonRoot
+  uid: 1001
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:gitea:default

--- a/distros/openshift/security-context-constraints/scc-porch-system-porch-server.yaml
+++ b/distros/openshift/security-context-constraints/scc-porch-system-porch-server.yaml
@@ -1,0 +1,13 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-porch-system-porch-server
+groups:
+- system:cluster-admins
+- system:nodes
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:porch-system:porch-server

--- a/distros/openshift/security-context-constraints/scc-resource-group-system-resource-group-sa.yaml
+++ b/distros/openshift/security-context-constraints/scc-resource-group-system-resource-group-sa.yaml
@@ -1,0 +1,16 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+allowPrivilegeEscalation: false
+readOnlyRootFilesystem: true
+metadata:
+  name: scc-resource-group-system-resource-group-sa
+groups:
+- system:cluster-admins
+- system:nodes
+runAsUser:
+  type: MustRunAsNonRoot
+  uid: 1000
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:resource-group-system:resource-group-sa

--- a/distros/openshift/security-context-constraints/scc-statefulset-gitea-default.yaml
+++ b/distros/openshift/security-context-constraints/scc-statefulset-gitea-default.yaml
@@ -1,0 +1,19 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-statefulset-gitea-default
+allowPrivilegeEscalation: true
+groups:
+- system:cluster-admins
+- system:nodes
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 1000
+      max: 1000
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:gitea:default

--- a/distros/openshift/security-context-constraints/scc-statefulset-postgres-default.yaml
+++ b/distros/openshift/security-context-constraints/scc-statefulset-postgres-default.yaml
@@ -1,0 +1,20 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: scc-statefulset-postgres-default
+allowPrivilegeEscalation: false
+groups:
+- system:cluster-admins
+- system:nodes
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 1001
+      max: 1001
+runAsUser:
+  type: MustRunAs
+  uid: 1001
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:gitea:default


### PR DESCRIPTION
Providing SCC definitions needed for deployment on OCP
This was merged to v3.0.0 in https://github.com/nephio-project/catalog/pull/72, so this is to add it to main