### PR TITLE
Add webhook config to gitea pkg

### DIFF
--- a/distros/sandbox/gitea/secret-gitea-inline-config.yaml
+++ b/distros/sandbox/gitea/secret-gitea-inline-config.yaml
@@ -23,6 +23,9 @@ stringData:
   metrics: ENABLED=false
   repository: ROOT=/data/git/gitea-repositories
   security: INSTALL_LOCK=true
+  webhook: |-
+    ALLOWED_HOST_LIST=*
+    SKIP_TLS_VERIFY=true
   server: |-
     APP_DATA_PATH=/data
     DOMAIN=git.example.com


### PR DESCRIPTION
Adding open webhook config to base gitea installation.
https://docs.gitea.com/administration/config-cheat-sheet#webhook-webhook 