### PR TITLE
o2ims operator kpt package

### DIFF
--- a/nephio/optional/o2ims/Kptfile
+++ b/nephio/optional/o2ims/Kptfile
@@ -1,0 +1,9 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: o2ims
+  namespace: o2ims
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: o2ims controller for FOCOM

--- a/nephio/optional/o2ims/README.md
+++ b/nephio/optional/o2ims/README.md
@@ -1,0 +1,32 @@
+# O2IMS Operator 
+
+This operator implements O-RAN O2 IMS cluster provisioning for K8s based cloud management.
+
+The CRD used by the operator is a work in-progress in O-RAN standards. It is part of `O-RAN.WG6.TS.O-CLOUD-IM.0-R004-v03.00`
+the work here is to provide a feedback to the standardization bodies with a PoC. 
+
+The operator code is present in [nephio/operators/o2ims-operator](https://github.com/nephio-project/nephio/tree/main/operators/o2ims-operator). 
+
+This repository contains the deployment files for the operator. 
+
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] o2ims`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree o2ims`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init o2ims
+kpt live apply o2ims --reconcile-timeout=2m --output=table
+```
+
+## Check operator is up and running
+```
+kubectl logs -n o2ims -l app.kubernetes.io/name=nephio-o2ims --tail=-1
+```

--- a/nephio/optional/o2ims/app/deployment.yaml
+++ b/nephio/optional/o2ims/app/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: o2ims-operator
+  namespace: o2ims
+  labels:
+    app.kubernetes.io/name: nephio-o2ims
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nephio-o2ims
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nephio-o2ims
+    spec:
+      securityContext:
+        runAsGroup: 0
+        runAsUser: 0
+      containers:
+      - name: nephio-o2ims
+        image: docker.io/nephio/o2ims-operator:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: 'GIT_REPOSITORY'
+          value: 'catalog-infra-capi'
+        - name: 'KUBERNETES_BASE_URL'
+          value: 'https://kubernetes.default.svc'
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "100m"
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccountName: o2ims-operator
+      terminationGracePeriodSeconds: 5

--- a/nephio/optional/o2ims/app/namespace.yaml
+++ b/nephio/optional/o2ims/app/namespace.yaml
@@ -1,0 +1,19 @@
+###########################################################################
+# Copyright 2022-2025 The Nephio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: o2ims

--- a/nephio/optional/o2ims/app/rbac.yaml
+++ b/nephio/optional/o2ims/app/rbac.yaml
@@ -1,0 +1,61 @@
+###########################################################################
+# Copyright 2022-2025 The Nephio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: o2ims:provisioning-role
+rules:
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create]
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [get, list, watch, create, update, patch]
+  - apiGroups: ["o2ims.provisioning.oran.org"]
+    resources: [provisioningrequests, provisioningrequests/status, provisioningrequests/finalizers]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: [clusters]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [admissionregistration.k8s.io/v1, admissionregistration.k8s.io/v1beta1]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [create, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: o2ims:provisioning
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: o2ims:provisioning-role
+subjects:
+  - kind: ServiceAccount
+    name: o2ims-operator
+    namespace: o2ims
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: o2ims:porch-controllers-packagevariants
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: porch-controllers-packagevariants
+subjects:
+- kind: ServiceAccount
+  name: o2ims-operator
+  namespace: o2ims

--- a/nephio/optional/o2ims/app/serviceaccount.yaml
+++ b/nephio/optional/o2ims/app/serviceaccount.yaml
@@ -1,0 +1,20 @@
+###########################################################################
+# Copyright 2022-2025 The Nephio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: o2ims
+  name: o2ims-operator

--- a/nephio/optional/o2ims/crd/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/nephio/optional/o2ims/crd/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -1,0 +1,132 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: provisioningrequests.o2ims.provisioning.oran.org
+spec:
+  group: o2ims.provisioning.oran.org
+  names:
+    kind: ProvisioningRequest
+    listKind: ProvisioningRequestList
+    plural: provisioningrequests
+    singular: provisioningrequest
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                The current apiVersion of this api is v1alpha1
+            kind:
+              type: string
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                The kind value for this api is ProvisioningRequest
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: |
+                    The name of the ProvisioningRequest custom resource instance contains the provisioningItemId.
+                    The provisioningItemId is the unique SMO provided identifier that the SMO will use to
+                    identify all resources provisioned by this provisioning request in interactions
+                    with the O-Cloud.
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: |
+                    the name in this spec section is a human readable name intended for descriptive
+                    purposes, this name is not required to be unique and does not identify a provisioning
+                    request or any provisioned resources.
+                description:
+                  type: string
+                  description: |
+                    A description of this provisioning request.
+                templateName:
+                  type: string
+                  description: |
+                    templateName is the name of the template that the SMO wants to use to provision
+                    resources
+                templateVersion:
+                  type: string
+                  description: |
+                    templateVersion is the version of the template that the SMO wants to use to provision
+                    resources. templateName and templateVersion together uniquely identify the template
+                    instance that the SMO wants to use in the provisioning request.
+                templateParameters:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    templateParams carries the parameters required to provision resources using this template.
+                    The type is object as actual parameters are defined by the template.
+                    The template parameter schema itself is not defined here as it is template specific.
+                    The themplate parameter schema must be published by the template provider so that FOCOM can
+                    learn about required parameters and validate the same.
+                    The template parameter schema language must be standardized by O-RAN.
+              required:
+                - templateName
+                - templateVersion
+                - templateParameters
+            status:
+              type: object
+              description: ProvisioningRequestStatus defines the observed state of ProvisioningRequest
+              properties:
+                provisionedResourceSet:
+                  description: |
+                    The resources that have been successfully provisioned as part of the provisioning process.
+                  properties:
+                    oCloudNodeClusterId:
+                      description: |
+                        The identifier of the provisioned oCloud NodeCluster.
+                      type: string
+                    oCloudInfrastructureResourceIds:
+                      description: |
+                        The list of provisioned infrastructure resource ids.
+                      type: array
+                      items:
+                        type: string
+                        description: |
+                          The provisioned infrastructure resource id.
+                  type: object
+                provisioningStatus:
+                  properties:
+                    provisioningUpdateTime:
+                      description: |
+                        The last update time of the provisioning status.
+                      format: date-time
+                      type: string
+                    provisioningMessage:
+                      description: |
+                        The details about the current state of the provisioning process.
+                      type: string
+                    provisioningState:
+                      description: The current state of the provisioning process.
+                      enum:
+                        - progressing
+                        - fulfilled
+                        - failed
+                        - deleting
+                      type: string
+                  type: object
+                extensions:
+                  description: |-
+                    Extensions contain extra details about the resources and the configuration used for/by
+                    the ProvisioningRequest.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/nephio/optional/o2ims/namespace.yaml
+++ b/nephio/optional/o2ims/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: o2ims


### PR DESCRIPTION
KPT package for o2ims operator. The image (`docker.io/nephio/o2ims-operator:latest`) used in this package does not exist in Nephio docker hub at the moment 

