### PR TITLE
Bugfix: Remove duplicate namespace in O2IMS

### DIFF
--- a/nephio/optional/o2ims/namespace.yaml
+++ b/nephio/optional/o2ims/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: o2ims


### PR DESCRIPTION
Removing second NS file that is causing an error in the O2IMS operator