### PR TITLE
adds runAsGroup and runAsUser fields to securityContext section

### DIFF
--- a/nephio/optional/o2ims/app/deployment.yaml
+++ b/nephio/optional/o2ims/app/deployment.yaml
@@ -19,6 +19,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsGroup: 65535
+        runAsUser: 65535
       containers:
       - name: nephio-o2ims
         image: docker.io/nephio/o2ims-operator:latest


### PR DESCRIPTION
This PR adds the runAsGroup and runAsUser fields to the securityContext section of the pod. If the fields are not added, the container does not come up as it is unable to verify if the user is nonroot.