### PR TITLE
Sync porch pkg contents from source repo deploy

### DIFF
--- a/nephio/core/porch/0-packagerevs.yaml
+++ b/nephio/core/porch/0-packagerevs.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/nephio/core/porch/0-packagevariants.yaml
+++ b/nephio/core/porch/0-packagevariants.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -107,20 +106,17 @@ spec:
                     type: array
                 type: object
               pipeline:
-                description: Pipeline declares a pipeline of functions used to mutate
-                  or validate resources.
+                description: Pipeline declares a pipeline of functions used to mutate or validate resources.
                 properties:
                   mutators:
-                    description: Mutators defines a list of of KRM functions that
-                      mutate resources.
+                    description: Mutators defines a list of of KRM functions that mutate resources.
                     items:
                       description: Function specifies a KRM function.
                       properties:
                         configMap:
                           additionalProperties:
                             type: string
-                          description: '`ConfigMap` is a convenient way to specify
-                            a function config of kind ConfigMap.'
+                          description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
                           type: object
                         configPath:
                           description: |-
@@ -163,18 +159,26 @@ spec:
                             type: object
                           type: array
                         exec:
-                          description: "Exec specifies the function binary executable.\nThe
-                            executable can be fully qualified or it must exists in
-                            the $PATH e.g:\n\n\t exec: set-namespace\n\t exec: /usr/local/bin/my-custom-fn"
+                          description: |-
+                            Exec specifies the function binary executable.
+                            The executable can be fully qualified or it must exists in the $PATH e.g:
+
+                            	 exec: set-namespace
+                            	 exec: /usr/local/bin/my-custom-fn
                           type: string
                         image:
-                          description: "`Image` specifies the function container image.\nIt
-                            can either be fully qualified, e.g.:\n\n\timage: gcr.io/kpt-fn/set-labels\n\nOptionally,
-                            kpt can be configured to use a image\nregistry host-path
-                            that will be used to resolve the image path in case\nthe
-                            image path is missing (Defaults to gcr.io/kpt-fn).\ne.g.
-                            The following resolves to gcr.io/kpt-fn/set-labels:\n\n\timage:
-                            set-labels"
+                          description: |-
+                            `Image` specifies the function container image.
+                            It can either be fully qualified, e.g.:
+
+                            	image: gcr.io/kpt-fn/set-labels
+
+                            Optionally, kpt can be configured to use a image
+                            registry host-path that will be used to resolve the image path in case
+                            the image path is missing (Defaults to gcr.io/kpt-fn).
+                            e.g. The following resolves to gcr.io/kpt-fn/set-labels:
+
+                            	image: set-labels
                           type: string
                         name:
                           description: |-
@@ -226,8 +230,7 @@ spec:
                         configMap:
                           additionalProperties:
                             type: string
-                          description: '`ConfigMap` is a convenient way to specify
-                            a function config of kind ConfigMap.'
+                          description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
                           type: object
                         configPath:
                           description: |-
@@ -270,18 +273,26 @@ spec:
                             type: object
                           type: array
                         exec:
-                          description: "Exec specifies the function binary executable.\nThe
-                            executable can be fully qualified or it must exists in
-                            the $PATH e.g:\n\n\t exec: set-namespace\n\t exec: /usr/local/bin/my-custom-fn"
+                          description: |-
+                            Exec specifies the function binary executable.
+                            The executable can be fully qualified or it must exists in the $PATH e.g:
+
+                            	 exec: set-namespace
+                            	 exec: /usr/local/bin/my-custom-fn
                           type: string
                         image:
-                          description: "`Image` specifies the function container image.\nIt
-                            can either be fully qualified, e.g.:\n\n\timage: gcr.io/kpt-fn/set-labels\n\nOptionally,
-                            kpt can be configured to use a image\nregistry host-path
-                            that will be used to resolve the image path in case\nthe
-                            image path is missing (Defaults to gcr.io/kpt-fn).\ne.g.
-                            The following resolves to gcr.io/kpt-fn/set-labels:\n\n\timage:
-                            set-labels"
+                          description: |-
+                            `Image` specifies the function container image.
+                            It can either be fully qualified, e.g.:
+
+                            	image: gcr.io/kpt-fn/set-labels
+
+                            Optionally, kpt can be configured to use a image
+                            registry host-path that will be used to resolve the image path in case
+                            the image path is missing (Defaults to gcr.io/kpt-fn).
+                            e.g. The following resolves to gcr.io/kpt-fn/set-labels:
+
+                            	image: set-labels
                           type: string
                         name:
                           description: |-
@@ -340,11 +351,9 @@ spec:
             description: PackageVariantStatus defines the observed state of PackageVariant
             properties:
               conditions:
-                description: Conditions describes the reconciliation state of the
-                  object.
+                description: Conditions describes the reconciliation state of the object.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -413,8 +422,7 @@ spec:
                         error:
                           type: string
                         result:
-                          description: ResultList contains aggregated results from
-                            multiple functions
+                          description: ResultList contains aggregated results from multiple functions
                           properties:
                             apiVersion:
                               description: |-
@@ -429,8 +437,7 @@ spec:
                             items:
                               description: Items contain a list of function result
                               items:
-                                description: Result contains the structured result
-                                  from an individual function
+                                description: Result contains the structured result from an individual function
                                 properties:
                                   exec:
                                     description: |-
@@ -439,8 +446,7 @@ spec:
                                       contain the entire input string.
                                     type: string
                                   exitCode:
-                                    description: ExitCode is the exit code from running
-                                      the function
+                                    description: ExitCode is the exit code from running the function
                                     type: integer
                                   image:
                                     description: |-
@@ -448,33 +454,25 @@ spec:
                                       Image and Exec are mutually exclusive
                                     type: string
                                   results:
-                                    description: Results is the list of results for
-                                      the function
+                                    description: Results is the list of results for the function
                                     items:
-                                      description: ResultItem defines a validation
-                                        result
+                                      description: ResultItem defines a validation result
                                       properties:
                                         field:
-                                          description: Field is a reference to the
-                                            field in a resource this result refers
-                                            to
+                                          description: Field is a reference to the field in a resource this result refers to
                                           properties:
                                             currentValue:
-                                              description: CurrentValue is the current
-                                                field value
+                                              description: CurrentValue is the current field value
                                               type: string
                                             path:
-                                              description: Path is the field path.
-                                                This field is required.
+                                              description: Path is the field path. This field is required.
                                               type: string
                                             proposedValue:
-                                              description: ProposedValue is the proposed
-                                                value of the field to fix an issue.
+                                              description: ProposedValue is the proposed value of the field to fix an issue.
                                               type: string
                                           type: object
                                         file:
-                                          description: File references a file containing
-                                            the resource this result refers to
+                                          description: File references a file containing the resource this result refers to
                                           properties:
                                             index:
                                               description: |-
@@ -488,8 +486,7 @@ spec:
                                               type: string
                                           type: object
                                         message:
-                                          description: Message is a human readable
-                                            message. This field is required.
+                                          description: Message is a human readable message. This field is required.
                                           type: string
                                         resourceRef:
                                           description: |-
@@ -512,17 +509,14 @@ spec:
                                                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                                               type: string
                                             name:
-                                              description: Name is the metadata.name
-                                                field of a Resource
+                                              description: Name is the metadata.name field of a Resource
                                               type: string
                                             namespace:
-                                              description: Namespace is the metadata.namespace
-                                                field of a Resource
+                                              description: Namespace is the metadata.namespace field of a Resource
                                               type: string
                                           type: object
                                         severity:
-                                          description: Severity is the severity of
-                                            this result
+                                          description: Severity is the severity of this result
                                           type: string
                                         tags:
                                           additionalProperties:

--- a/nephio/core/porch/0-packagevariantsets.yaml
+++ b/nephio/core/porch/0-packagevariantsets.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 The kpt and Nephio Authors
+# Copyright 2022-2025 The kpt and Nephio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -71,8 +70,7 @@ spec:
                 items:
                   properties:
                     objects:
-                      description: 'option 3: a selector against a set of arbitrary
-                        objects'
+                      description: 'option 3: a selector against a set of arbitrary objects'
                       properties:
                         repoName:
                           properties:
@@ -99,17 +97,14 @@ spec:
                                 description: Labels on the target resources
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
                                       description: |-
                                         A label selector requirement is a selector that contains values, a key, and an operator that
                                         relates the key and values.
                                       properties:
                                         key:
-                                          description: key is the label key that the
-                                            selector applies to.
+                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
                                           description: |-
@@ -190,16 +185,14 @@ spec:
                       description: 'option 2: a label selector against a set of repositories'
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
                             description: |-
                               A label selector requirement is a selector that contains values, a key, and an operator that
                               relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
+                                description: key is the label key that the selector applies to.
                                 type: string
                               operator:
                                 description: |-
@@ -253,11 +246,9 @@ spec:
             description: PackageVariantSetStatus defines the observed state of PackageVariantSet
             properties:
               conditions:
-                description: Conditions describes the reconciliation state of the
-                  object.
+                description: Conditions describes the reconciliation state of the object.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -348,8 +339,7 @@ spec:
                 items:
                   properties:
                     objectSelector:
-                      description: 'option 3: a selector against a set of arbitrary
-                        objects'
+                      description: 'option 3: a selector against a set of arbitrary objects'
                       properties:
                         apiVersion:
                           description: APIVersion of the target resources
@@ -358,16 +348,14 @@ spec:
                           description: Kind of the target resources
                           type: string
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
                             description: |-
                               A label selector requirement is a selector that contains values, a key, and an operator that
                               relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
+                                description: key is the label key that the selector applies to.
                                 type: string
                               operator:
                                 description: |-
@@ -430,16 +418,14 @@ spec:
                       description: 'option 2: a label selector against a set of repositories'
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
                             description: |-
                               A label selector requirement is a selector that contains values, a key, and an operator that
                               relates the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
+                                description: key is the label key that the selector applies to.
                                 type: string
                               operator:
                                 description: |-
@@ -473,12 +459,10 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     template:
-                      description: Template specifies how to generate a PackageVariant
-                        from a target
+                      description: Template specifies how to generate a PackageVariant from a target
                       properties:
                         adoptionPolicy:
-                          description: AdoptionPolicy allows overriding the PackageVariant
-                            adoption policy
+                          description: AdoptionPolicy allows overriding the PackageVariant adoption policy
                           type: string
                         annotationExprs:
                           description: |-
@@ -504,16 +488,13 @@ spec:
                         annotations:
                           additionalProperties:
                             type: string
-                          description: Annotations allows specifying the spec.Annotations
-                            field of the generated PackageVariant
+                          description: Annotations allows specifying the spec.Annotations field of the generated PackageVariant
                           type: object
                         deletionPolicy:
-                          description: DeletionPolicy allows overriding the PackageVariant
-                            deletion policy
+                          description: DeletionPolicy allows overriding the PackageVariant deletion policy
                           type: string
                         downstream:
-                          description: Downstream allows overriding the default downstream
-                            package and repository name
+                          description: Downstream allows overriding the default downstream package and repository name
                           properties:
                             package:
                               type: string
@@ -525,8 +506,7 @@ spec:
                               type: string
                           type: object
                         injectors:
-                          description: Injectors allows specifying the spec.Injectors
-                            field of the generated PackageVariant
+                          description: Injectors allows specifying the spec.Injectors field of the generated PackageVariant
                           items:
                             description: |-
                               InjectionSelectorTemplate is used to calculate the injectors field of the
@@ -569,12 +549,10 @@ spec:
                         labels:
                           additionalProperties:
                             type: string
-                          description: Labels allows specifying the spec.Labels field
-                            of the generated PackageVariant
+                          description: Labels allows specifying the spec.Labels field of the generated PackageVariant
                           type: object
                         packageContext:
-                          description: PackageContext allows specifying the spec.PackageContext
-                            field of the generated PackageVariant
+                          description: PackageContext allows specifying the spec.PackageContext field of the generated PackageVariant
                           properties:
                             data:
                               additionalProperties:
@@ -607,8 +585,7 @@ spec:
                               type: array
                           type: object
                         pipeline:
-                          description: Pipeline allows specifying the spec.Pipeline
-                            field of the generated PackageVariant
+                          description: Pipeline allows specifying the spec.Pipeline field of the generated PackageVariant
                           properties:
                             mutators:
                               description: |-
@@ -622,8 +599,7 @@ spec:
                                   configMap:
                                     additionalProperties:
                                       type: string
-                                    description: '`ConfigMap` is a convenient way
-                                      to specify a function config of kind ConfigMap.'
+                                    description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
                                     type: object
                                   configMapExprs:
                                     description: |-
@@ -687,20 +663,26 @@ spec:
                                       type: object
                                     type: array
                                   exec:
-                                    description: "Exec specifies the function binary
-                                      executable.\nThe executable can be fully qualified
-                                      or it must exists in the $PATH e.g:\n\n\t exec:
-                                      set-namespace\n\t exec: /usr/local/bin/my-custom-fn"
+                                    description: |-
+                                      Exec specifies the function binary executable.
+                                      The executable can be fully qualified or it must exists in the $PATH e.g:
+
+                                      	 exec: set-namespace
+                                      	 exec: /usr/local/bin/my-custom-fn
                                     type: string
                                   image:
-                                    description: "`Image` specifies the function container
-                                      image.\nIt can either be fully qualified, e.g.:\n\n\timage:
-                                      gcr.io/kpt-fn/set-labels\n\nOptionally, kpt
-                                      can be configured to use a image\nregistry host-path
-                                      that will be used to resolve the image path
-                                      in case\nthe image path is missing (Defaults
-                                      to gcr.io/kpt-fn).\ne.g. The following resolves
-                                      to gcr.io/kpt-fn/set-labels:\n\n\timage: set-labels"
+                                    description: |-
+                                      `Image` specifies the function container image.
+                                      It can either be fully qualified, e.g.:
+
+                                      	image: gcr.io/kpt-fn/set-labels
+
+                                      Optionally, kpt can be configured to use a image
+                                      registry host-path that will be used to resolve the image path in case
+                                      the image path is missing (Defaults to gcr.io/kpt-fn).
+                                      e.g. The following resolves to gcr.io/kpt-fn/set-labels:
+
+                                      	image: set-labels
                                     type: string
                                   name:
                                     description: |-
@@ -754,8 +736,7 @@ spec:
                                   configMap:
                                     additionalProperties:
                                       type: string
-                                    description: '`ConfigMap` is a convenient way
-                                      to specify a function config of kind ConfigMap.'
+                                    description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
                                     type: object
                                   configMapExprs:
                                     description: |-
@@ -819,20 +800,26 @@ spec:
                                       type: object
                                     type: array
                                   exec:
-                                    description: "Exec specifies the function binary
-                                      executable.\nThe executable can be fully qualified
-                                      or it must exists in the $PATH e.g:\n\n\t exec:
-                                      set-namespace\n\t exec: /usr/local/bin/my-custom-fn"
+                                    description: |-
+                                      Exec specifies the function binary executable.
+                                      The executable can be fully qualified or it must exists in the $PATH e.g:
+
+                                      	 exec: set-namespace
+                                      	 exec: /usr/local/bin/my-custom-fn
                                     type: string
                                   image:
-                                    description: "`Image` specifies the function container
-                                      image.\nIt can either be fully qualified, e.g.:\n\n\timage:
-                                      gcr.io/kpt-fn/set-labels\n\nOptionally, kpt
-                                      can be configured to use a image\nregistry host-path
-                                      that will be used to resolve the image path
-                                      in case\nthe image path is missing (Defaults
-                                      to gcr.io/kpt-fn).\ne.g. The following resolves
-                                      to gcr.io/kpt-fn/set-labels:\n\n\timage: set-labels"
+                                    description: |-
+                                      `Image` specifies the function container image.
+                                      It can either be fully qualified, e.g.:
+
+                                      	image: gcr.io/kpt-fn/set-labels
+
+                                      Optionally, kpt can be configured to use a image
+                                      registry host-path that will be used to resolve the image path in case
+                                      the image path is missing (Defaults to gcr.io/kpt-fn).
+                                      e.g. The following resolves to gcr.io/kpt-fn/set-labels:
+
+                                      	image: set-labels
                                     type: string
                                   name:
                                     description: |-
@@ -894,11 +881,9 @@ spec:
             description: PackageVariantSetStatus defines the observed state of PackageVariantSet
             properties:
               conditions:
-                description: Conditions describes the reconciliation state of the
-                  object.
+                description: Conditions describes the reconciliation state of the object.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-

--- a/nephio/core/porch/0-repositories.yaml
+++ b/nephio/core/porch/0-repositories.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -79,35 +78,33 @@ spec:
                   For partial backward compatibility it is still recognized, but its only valid value is "Package", and if not specified its default value is also "Package".
                 type: string
                 x-kubernetes-validations:
-                - message: The 'content' field is deprecated, its only valid value
-                    is 'Package'
+                - message: The 'content' field is deprecated, its only valid value is 'Package'
                   rule: self == '' || self == 'Package'
               deployment:
-                description: The repository is a deployment repository; final packages
-                  in this repository are deployment ready.
+                description: The repository is a deployment repository; final packages in this repository are deployment ready.
                 type: boolean
               description:
                 description: User-friendly description of the repository
                 type: string
               git:
-                description: Git repository details. Required if `type` is `git`.
-                  Ignored if `type` is not `git`.
+                description: Git repository details. Required if `type` is `git`. Ignored if `type` is not `git`.
                 properties:
+                  author:
+                    description: Author to use for commits
+                    type: string
                   branch:
                     default: main
-                    description: Name of the branch containing the packages. Finalized
-                      packages will be committed to this branch (if the repository
-                      allows write access). If unspecified, defaults to "main".
+                    description: Name of the branch containing the packages. Finalized packages will be committed to this branch (if the repository allows write access). If unspecified, defaults to "main".
                     minLength: 1
                     type: string
                   createBranch:
-                    description: CreateBranch specifies if Porch should create the
-                      package branch if it doesn't exist.
+                    description: CreateBranch specifies if Porch should create the package branch if it doesn't exist.
                     type: boolean
                   directory:
-                    description: Directory within the Git repository where the packages
-                      are stored. A subdirectory of this directory containing a Kptfile
-                      is considered a package. If unspecified, defaults to root directory.
+                    description: Directory within the Git repository where the packages are stored. A subdirectory of this directory containing a Kptfile is considered a package. If unspecified, defaults to root directory.
+                    type: string
+                  email:
+                    description: Email to use for commits
                     type: string
                   repo:
                     description: |-
@@ -118,9 +115,7 @@ spec:
                     description: Reference to secret containing authentication credentials.
                     properties:
                       name:
-                        description: Name of the secret. The secret is expected to
-                          be located in the same namespace as the resource containing
-                          the reference.
+                        description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
                         type: string
                     required:
                     - name
@@ -128,28 +123,8 @@ spec:
                 required:
                 - repo
                 type: object
-              mutators:
-                description: |-
-                  `Mutators` specifies list of functions to be added to the list of package's mutators on changes to the packages in the repository to ensure the packages meet constraints
-                  enforced by the mutators associated with the repository.
-                  Based on the Kubernetest Admission Controllers (https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). The functions will be evaluated
-                  in the order specified in the list.
-                items:
-                  properties:
-                    configMap:
-                      additionalProperties:
-                        type: string
-                      description: '`ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/).'
-                      type: object
-                    image:
-                      description: '`Image` specifies the function image, such as
-                        `gcr.io/kpt-fn/gatekeeper:v0.2`.'
-                      type: string
-                  type: object
-                type: array
               oci:
-                description: OCI repository details. Required if `type` is `oci`.
-                  Ignored if `type` is not `oci`.
+                description: OCI repository details. Required if `type` is `oci`. Ignored if `type` is not `oci`.
                 properties:
                   registry:
                     description: Registry is the address of the OCI registry
@@ -158,9 +133,7 @@ spec:
                     description: Reference to secret containing authentication credentials.
                     properties:
                       name:
-                        description: Name of the secret. The secret is expected to
-                          be located in the same namespace as the resource containing
-                          the reference.
+                        description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
                         type: string
                     required:
                     - name
@@ -171,119 +144,14 @@ spec:
               type:
                 description: Type of the repository (i.e. git, OCI)
                 type: string
-              upstream:
-                description: |-
-                  Upstream is the default upstream repository for packages in this
-                  repository. Specifying it per repository allows simpler UX when
-                  creating packages.
-                properties:
-                  git:
-                    description: Git repository details. Required if `type` is `git`.
-                      Must be unspecified if `type` is not `git`.
-                    properties:
-                      branch:
-                        default: main
-                        description: Name of the branch containing the packages. Finalized
-                          packages will be committed to this branch (if the repository
-                          allows write access). If unspecified, defaults to "main".
-                        minLength: 1
-                        type: string
-                      createBranch:
-                        description: CreateBranch specifies if Porch should create
-                          the package branch if it doesn't exist.
-                        type: boolean
-                      directory:
-                        description: Directory within the Git repository where the
-                          packages are stored. A subdirectory of this directory containing
-                          a Kptfile is considered a package. If unspecified, defaults
-                          to root directory.
-                        type: string
-                      repo:
-                        description: |-
-                          Address of the Git repository, for example:
-                            `https://github.com/GoogleCloudPlatform/blueprints.git`
-                        type: string
-                      secretRef:
-                        description: Reference to secret containing authentication
-                          credentials.
-                        properties:
-                          name:
-                            description: Name of the secret. The secret is expected
-                              to be located in the same namespace as the resource
-                              containing the reference.
-                            type: string
-                        required:
-                        - name
-                        type: object
-                    required:
-                    - repo
-                    type: object
-                  oci:
-                    description: OCI repository details. Required if `type` is `oci`.
-                      Must be unspecified if `type` is not `oci`.
-                    properties:
-                      registry:
-                        description: Registry is the address of the OCI registry
-                        type: string
-                      secretRef:
-                        description: Reference to secret containing authentication
-                          credentials.
-                        properties:
-                          name:
-                            description: Name of the secret. The secret is expected
-                              to be located in the same namespace as the resource
-                              containing the reference.
-                            type: string
-                        required:
-                        - name
-                        type: object
-                    required:
-                    - registry
-                    type: object
-                  repositoryRef:
-                    description: RepositoryRef contains a reference to an existing
-                      Repository resource to be used as the default upstream repository.
-                    properties:
-                      name:
-                        description: Name of the Repository resource referenced.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type:
-                    description: Type of the repository (i.e. git, OCI). If empty,
-                      repositoryRef will be used.
-                    type: string
-                type: object
-              validators:
-                description: |-
-                  `Validators` specifies list of functions to be added to the list of package's validators on changes to the packages in the repository to ensure the packages meet constraints
-                  enforced by the validators associated with the repository.
-                  Based on the Kubernetest Admission Controllers (https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). The functions will be evaluated
-                  in the order specified in the list.
-                items:
-                  properties:
-                    configMap:
-                      additionalProperties:
-                        type: string
-                      description: '`ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/).'
-                      type: object
-                    image:
-                      description: '`Image` specifies the function image, such as
-                        `gcr.io/kpt-fn/gatekeeper:v0.2`.'
-                      type: string
-                  type: object
-                type: array
             type: object
           status:
             description: RepositoryStatus defines the observed state of Repository
             properties:
               conditions:
-                description: Conditions describes the reconciliation state of the
-                  object.
+                description: Conditions describes the reconciliation state of the object.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -338,6 +206,11 @@ spec:
                 type: array
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must conform to the RFC1123 DNS label standard
+          rule: self.metadata.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+        - message: metadata.name must be no more than 63 characters
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:

--- a/nephio/core/porch/3-porch-server.yaml
+++ b/nephio/core/porch/3-porch-server.yaml
@@ -80,7 +80,6 @@ spec:
             - --repo-sync-frequency=3m
             - --disable-validating-admissions-policy=true
             - --max-request-body-size=6291456 # Keep this in sync with function-runner's corresponding argument
-
           #adding livenessProbes and readinessProbes for porch server
           livenessProbe:
             httpGet:
@@ -101,7 +100,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
             successThreshold: 1
-            timeoutSeconds: 3                            
+            timeoutSeconds: 3
 ---
 apiVersion: v1
 kind: Service

--- a/nephio/core/porch/5-rbac.yaml
+++ b/nephio/core/porch/5-rbac.yaml
@@ -70,6 +70,12 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - get
   # Needed for priority and fairness
   - apiGroups:
       - flowcontrol.apiserver.k8s.io
@@ -80,12 +86,6 @@ rules:
       - get
       - watch
       - list
-  - apiGroups:
-      - apiregistration.k8s.io
-    resources: 
-      - apiservices
-    verbs:
-      - get
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -132,5 +132,5 @@ rules:
     verbs:
       - create
       - delete
-      - get
       - update
+      - get

--- a/nephio/core/porch/9-controllers.yaml
+++ b/nephio/core/porch/9-controllers.yaml
@@ -66,4 +66,4 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
           successThreshold: 1
-          timeoutSeconds: 3            
+          timeoutSeconds: 3

--- a/nephio/core/porch/9-porch-controller-clusterrole.yaml
+++ b/nephio/core/porch/9-porch-controller-clusterrole.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022-2025 The kpt and Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/nephio/core/porch/9-porch-controller-packagevariants-clusterrole.yaml
+++ b/nephio/core/porch/9-porch-controller-packagevariants-clusterrole.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022-2025 The kpt and Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -41,17 +54,6 @@ rules:
   - porch.kpt.dev
   resources:
   - packagerevisionresources
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - porch.kpt.dev
-  resources:
   - packagerevisions
   verbs:
   - create

--- a/nephio/core/porch/9-porch-controller-packagevariantsets-clusterrole.yaml
+++ b/nephio/core/porch/9-porch-controller-packagevariantsets-clusterrole.yaml
@@ -1,3 +1,16 @@
+# Copyright 2022-2025 The kpt and Nephio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
Prelim step to sync catalog porch pkg and pkg that is generated from the porch deploy-config make target.
With a view to automate the sync via creating a PR when there is a change on source repo.