### PR TITLE
Use workspaceName on PacakageVariant upstream references

### DIFF
--- a/infra/capi/nephio-workload-cluster-flux/pv-cluster.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: cluster-capi-kind
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-cluster
     repo: mgmt

--- a/infra/capi/nephio-workload-cluster-flux/pv-crds.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-crds.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: workload-crds
     repo: catalog-nephio-core
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-crds
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster-flux/pv-flux-gitrepo-kustomize.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-flux-gitrepo-kustomize.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: flux-gitrepo-kustomize
     repo: catalog-nephio-optional
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-flux-gitrepo-kustomize
     repo: mgmt

--- a/infra/capi/nephio-workload-cluster-flux/pv-kindnet.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-kindnet.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: kindnet
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-kindnet
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster-flux/pv-local-path-provisioner.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-local-path-provisioner.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: local-path-provisioner
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-local-path-provisioner
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster-flux/pv-metallb.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-metallb.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: metallb
     repo: catalog-distros-sandbox
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-metallb
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster-flux/pv-multus.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-multus.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: multus
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-multus
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster-flux/pv-repo.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-repo.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: repository
     repo: catalog-distros-sandbox
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-repo
     repo: mgmt

--- a/infra/capi/nephio-workload-cluster-flux/pv-vlanindex.yaml
+++ b/infra/capi/nephio-workload-cluster-flux/pv-vlanindex.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: vlanindex
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-vlanindex
     repo: mgmt

--- a/infra/capi/nephio-workload-cluster/pv-cluster.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: cluster-capi-kind
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-cluster
     repo: mgmt

--- a/infra/capi/nephio-workload-cluster/pv-configsync.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-configsync.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: configsync
     repo: catalog-nephio-core
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-configsync
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster/pv-crds.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-crds.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: workload-crds
     repo: catalog-nephio-core
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-crds
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster/pv-kindnet.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-kindnet.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: kindnet
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-kindnet
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster/pv-local-path-provisioner.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-local-path-provisioner.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: local-path-provisioner
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-local-path-provisioner
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster/pv-metallb.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-metallb.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: metallb
     repo: catalog-distros-sandbox
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-metallb
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster/pv-multus.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-multus.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: multus
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-multus
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster/pv-repo.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-repo.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: repository
     repo: catalog-distros-sandbox
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-repo
     repo: mgmt

--- a/infra/capi/nephio-workload-cluster/pv-rootsync.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-rootsync.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: rootsync
     repo: catalog-nephio-optional
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-rootsync
     repo: mgmt-staging

--- a/infra/capi/nephio-workload-cluster/pv-vlanindex.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-vlanindex.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: vlanindex
     repo: catalog-infra-capi
-    revision: -1
+    workspaceName: main
   downstream:
     package: example-vlanindex
     repo: mgmt

--- a/infra/gcp/nephio-blueprint-repo/pv-repo.yaml
+++ b/infra/gcp/nephio-blueprint-repo/pv-repo.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: cc-repo-csr
     repo: blueprints-infra-gcp
-    revision: -1
+    workspaceName: main
   downstream:
     package: example
     repo: config-control

--- a/infra/gcp/nephio-workload-cluster-gke/pv-cluster.yaml
+++ b/infra/gcp/nephio-workload-cluster-gke/pv-cluster.yaml
@@ -8,7 +8,7 @@ spec:
   upstream:
     package: cc-cluster-gke-std-csr-cs
     repo: blueprints-infra-gcp
-    revision: -1
+    workspaceName: main
   downstream:
     package: example
     repo: config-control

--- a/workloads/oai/package-variants/oai-cucp.yaml
+++ b/workloads/oai/package-variants/oai-cucp.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: catalog-workloads-oai
     package: pkg-example-cucp-bp
-    revision: -1
+    workspaceName: main
   downstream:
     repo: regional
     package: oai-ran-cucp

--- a/workloads/oai/package-variants/oai-cuup.yaml
+++ b/workloads/oai/package-variants/oai-cuup.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: catalog-workloads-oai
     package: pkg-example-cuup-bp
-    revision: -1
+    workspaceName: main
   downstream:
     repo: edge
     package: oai-ran-cuup

--- a/workloads/oai/package-variants/oai-du.yaml
+++ b/workloads/oai/package-variants/oai-du.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: catalog-workloads-oai
     package: pkg-example-du-bp
-    revision: -1
+    workspaceName: main
   downstream:
     repo: edge
     package: oai-ran-du

--- a/workloads/oai/package-variants/oai-ran-operator.yaml
+++ b/workloads/oai/package-variants/oai-ran-operator.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: catalog-workloads-oai
     package: oai-ran-operator
-    revision: -1
+    workspaceName: main
   targets:
   - objectSelector:
       apiVersion: infra.nephio.org/v1alpha1

--- a/workloads/oai/package-variants/oai-ue.yaml
+++ b/workloads/oai/package-variants/oai-ue.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: catalog-workloads-oai
     package: pkg-example-ue-bp
-    revision: -1
+    workspaceName: main
   downstream:
     repo: edge
     package: oai-ran-ue

--- a/workloads/ric/package-variants/ric-operator.yaml
+++ b/workloads/ric/package-variants/ric-operator.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: catalog-workloads-oai
     package: ric-operator
-    revision: -1
+    workspaceName: main
   targets:
   - objectSelector:
       apiVersion: infra.nephio.org/v1alpha1

--- a/workloads/ric/package-variants/ric.yaml
+++ b/workloads/ric/package-variants/ric.yaml
@@ -6,7 +6,7 @@ spec:
   upstream:
     repo: catalog-workloads-ric
     package: pkg-example-ric
-    revision: -1
+    workspaceName: main
   downstream:
     repo: regional
     package: ric


### PR DESCRIPTION
For now we are using workspace name to refer to upstream package revisions on PRs. 