### PR TITLE
free5gc blueprint packages: align SMF's Kpt pipeline with AMF and UPF

### DIFF
--- a/workloads/free5gc/pkg-example-smf-bp/Kptfile
+++ b/workloads/free5gc/pkg-example-smf-bp/Kptfile
@@ -20,3 +20,4 @@ pipeline:
     - image: docker.io/nephio/nad-fn:latest
     - image: docker.io/nephio/dnn-fn:latest
     - image: docker.io/nephio/interface-fn:latest
+    - image: docker.io/nephio/nfdeploy-fn:latest


### PR DESCRIPTION
As in the AMF and UPF blueprints, add one more call of the `nfdeploy-fn` kpt function at the end of the Kpt pipeline to make it become ready more reliably.

When deploying the SMF blueprint package through Porch (for example, in the case of the free5gc test flow), the final mutations for the resulting downstream package revision to be ready (and eligible for propose-and-approve) are done by one last run of `nfdeploy-fn`.
Currently this last run occurs in the course of a Kpt render triggered by Porch performing one last update to the package revision's Kptfile, to reorganise several sections (without any actual changes to the content) including the order of fields and the sorting of the readiness conditions in the `status.conditions` section.

I suspect Porch's current inconsistent handling of Kptfile structure (field order, condition sorting, etc.) has been concealing the reliance on a final Kpt render, by making Porch update the package revision frequently enough that it regularly triggers a render anyway causes *that* render's *first* run of `nfdeploy-fn` to perform the required updates.

However, ongoing work on [Porch issue 615](https://github.com/nephio-project/nephio/issues/615) includes improvements to Porch to make its parsing of Kptfiles more consistent and unified. This results in significantly fewer such "busywork" updates to the Kptfile, and correspondingly less chance of having an update trigger the Kpt render and perform the final mutations. As a consequence, the SMF package's deployment effectively becomes increasingly flaky (with the few successful deployments requiring a wait of anything from 5 to 20 minutes or a restart of Porch pods), and the free5gc test flow along with it.
