### PR TITLE
Added kpt-set for GIT_URL and GIT_NAMESPACE env vars

### DIFF
--- a/nephio/core/nephio-operator/app/controller/deployment-token-controller.yaml
+++ b/nephio/core/nephio-operator/app/controller/deployment-token-controller.yaml
@@ -70,9 +70,9 @@ spec:
               apiVersion: v1
               fieldPath: status.hostIP
         - name: GIT_URL
-          value: http://172.18.0.200:3000
+          value: http://172.18.0.200:3000 # kpt-set: ${git_url}
         - name: GIT_NAMESPACE
-          value: gitea
+          value: gitea # kpt-set: ${git_namespace}
         - name: ENABLE_TOKENS
           value: "true"
         image: docker.io/nephio/nephio-operator:latest


### PR DESCRIPTION
In case you need to use an external git provider, the kpt comments might be useful (especially the GIT_URL env variable), so that it is easier to use kpt to replace the values (instead of doing it manually or in a non-kpt way).