### PR TITLE
Replace deprecated gcr.io/kubebuilder/kube-rbac-proxy image with quay.io/brancz mirror

### DIFF
--- a/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-controller.yaml
@@ -32,7 +32,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-token-controller.yaml
+++ b/distros/gcp/nephio-mgmt/nephio-controllers/app/controller/deployment-token-controller.yaml
@@ -32,7 +32,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/distros/gcp/nephio-mgmt/network-config/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/network-config/app/controller/deployment-controller.yaml
@@ -32,7 +32,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/distros/gcp/nephio-mgmt/resource-backend/app/controller/deployment-controller.yaml
+++ b/distros/gcp/nephio-mgmt/resource-backend/app/controller/deployment-controller.yaml
@@ -32,7 +32,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/nephio/core/nephio-operator/app/controller/deployment-controller.yaml
+++ b/nephio/core/nephio-operator/app/controller/deployment-controller.yaml
@@ -31,7 +31,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/nephio/core/nephio-operator/app/controller/deployment-token-controller.yaml
+++ b/nephio/core/nephio-operator/app/controller/deployment-token-controller.yaml
@@ -31,7 +31,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/nephio/optional/network-config/app/controller/deployment-controller.yaml
+++ b/nephio/optional/network-config/app/controller/deployment-controller.yaml
@@ -31,7 +31,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/nephio/optional/resource-backend/app/controller/deployment-controller.yaml
+++ b/nephio/optional/resource-backend/app/controller/deployment-controller.yaml
@@ -33,7 +33,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/nephio/optional/spiffe-nephio-operator/app/controller/deployment-controller.yaml
+++ b/nephio/optional/spiffe-nephio-operator/app/controller/deployment-controller.yaml
@@ -31,7 +31,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/nephio/optional/spiffe-nephio-operator/app/controller/deployment-token-controller.yaml
+++ b/nephio/optional/spiffe-nephio-operator/app/controller/deployment-token-controller.yaml
@@ -31,7 +31,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/workloads/free5gc/free5gc-operator/operator/deployment.yaml
+++ b/workloads/free5gc/free5gc-operator/operator/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: free5gc-operator
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/


### PR DESCRIPTION
## Problem

The `gcr.io/kubebuilder` container registry has been decommissioned (see the [GCR transition notice](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr)). As a result `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` now returns `NotFound`:

```
Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0": rpc error: code = NotFound
desc = failed to resolve reference "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0": not found
```

Every controller that ships this sidecar (nephio-operator, nephio-controllers, network-config, resource-backend, spiffe-nephio-operator, free5gc-operator) goes into `ImagePullBackOff`. During a sandbox/`kpt live apply` install this makes the *"wait for deployments"* step time out and the whole install aborts **before Porch is deployed**.

Fixes nephio-project/nephio#1167.

## Fix

Repoint all 11 references from `gcr.io/kubebuilder/kube-rbac-proxy` to the maintainer's own registry `quay.io/brancz/kube-rbac-proxy` (kube-rbac-proxy is authored by @brancz). The version tag (`v0.8.0`) is unchanged and is published there, so this is a drop-in, behaviour-preserving swap.

## Verification

Reproduced on a fresh Nephio R6 KIND sandbox (`NEPHIO_BRANCH=main`): the install aborted at the resource-backend wait with the error above. After pointing the image at `quay.io/brancz/kube-rbac-proxy:v0.8.0`, the controller reached `2/2 Running` and the install proceeded to deploy Porch and the remaining components.

## Note / future work

The longer-term direction recommended by kubebuilder is to drop the kube-rbac-proxy sidecar entirely in favour of controller-runtime's `WithAuthenticationAndAuthorization` metrics filter. That requires controller code changes + image rebuilds and is out of scope here; this PR is the minimal change to unblock installs today.