### PR TITLE
Pin Porch images to v1.5.7 instead of the drifting :latest tag

### DIFF
--- a/distros/gcp/nephio-mgmt/porch/2-function-runner.yaml
+++ b/distros/gcp/nephio-mgmt/porch/2-function-runner.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: porch-fn-runner
       containers:
         - name: function-runner
-          image: docker.io/nephio/porch-function-runner:latest
+          image: docker.io/nephio/porch-function-runner:v1.5.7
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -54,7 +54,7 @@ spec:
             - --warm-up-pod-cache=true
           env:
             - name: WRAPPER_SERVER_IMAGE
-              value: docker.io/nephio/porch-wrapper-server:latest
+              value: docker.io/nephio/porch-wrapper-server:v1.5.7
           ports:
             - containerPort: 9445
           # Add grpc readiness probe to ensure the cache is ready

--- a/distros/gcp/nephio-mgmt/porch/3-porch-server.yaml
+++ b/distros/gcp/nephio-mgmt/porch/3-porch-server.yaml
@@ -48,7 +48,7 @@ spec:
       containers:
         - name: porch-server
           # Update image to the image of your porch apiserver build.
-          image: docker.io/nephio/porch-server:latest
+          image: docker.io/nephio/porch-server:v1.5.7
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/distros/gcp/nephio-mgmt/porch/9-controllers.yaml
+++ b/distros/gcp/nephio-mgmt/porch/9-controllers.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
       - name: porch-controllers
         # Update to the image of your porch-controllers build.
-        image: docker.io/nephio/porch-controllers:latest
+        image: docker.io/nephio/porch-controllers:v1.5.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: true

--- a/nephio/core/porch/2-function-runner.yaml
+++ b/nephio/core/porch/2-function-runner.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: porch-fn-runner
       containers:
         - name: function-runner
-          image: docker.io/nephio/porch-function-runner:latest
+          image: docker.io/nephio/porch-function-runner:v1.5.7
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -51,7 +51,7 @@ spec:
             - --warm-up-pod-cache=true
           env:
             - name: WRAPPER_SERVER_IMAGE
-              value: docker.io/nephio/porch-wrapper-server:latest
+              value: docker.io/nephio/porch-wrapper-server:v1.5.7
           ports:
             - containerPort: 9445
           # Add grpc readiness probe to ensure the cache is ready

--- a/nephio/core/porch/3-porch-server.yaml
+++ b/nephio/core/porch/3-porch-server.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: porch-server
           # Update image to the image of your porch apiserver build.
-          image: docker.io/nephio/porch-server:latest
+          image: docker.io/nephio/porch-server:v1.5.7
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/nephio/core/porch/9-controllers.yaml
+++ b/nephio/core/porch/9-controllers.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: porch-controllers
         # Update to the image of your porch-controllers build.
-        image: docker.io/nephio/porch-controllers:latest
+        image: docker.io/nephio/porch-controllers:v1.5.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: true

--- a/nephio/optional/porch-cert-manager-webhook/2-function-runner.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/2-function-runner.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: porch-fn-runner
       containers:
         - name: function-runner
-          image: docker.io/nephio/porch-function-runner:latest
+          image: docker.io/nephio/porch-function-runner:v1.5.7
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -50,7 +50,7 @@ spec:
             - --warm-up-pod-cache=true
           env:
             - name: WRAPPER_SERVER_IMAGE
-              value: docker.io/nephio/porch-wrapper-server:latest
+              value: docker.io/nephio/porch-wrapper-server:v1.5.7
           ports:
             - containerPort: 9445
           # Add grpc readiness probe to ensure the cache is ready

--- a/nephio/optional/porch-cert-manager-webhook/3-porch-server.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/3-porch-server.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: porch-server
           # Update image to the image of your porch apiserver build.
-          image: docker.io/nephio/porch-server:latest
+          image: docker.io/nephio/porch-server:v1.5.7
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/nephio/optional/porch-cert-manager-webhook/9-controllers.yaml
+++ b/nephio/optional/porch-cert-manager-webhook/9-controllers.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: porch-controllers
         # Update to the image of your porch-controllers build.
-        image: docker.io/nephio/porch-controllers:latest
+        image: docker.io/nephio/porch-controllers:v1.5.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
The Porch packages pin their images to the mutable `:latest` tag:

- `nephio/core/porch`
- `nephio/optional/porch-cert-manager-webhook`
- `distros/gcp/nephio-mgmt/porch`

Today's `:latest` images have drifted past these manifests, so a fresh install crash-loops and never comes up:

```
porch-server:    Error: unknown flag: --repo-sync-frequency
function-runner: flag provided but not defined: -config
function-runner: no matches for kind "FunctionConfig" in config.porch.kpt.dev/v1alpha1
function-runner: porch-fn-runner cannot list resource "podtemplates" (forbidden)
```

Root cause: no published image satisfies these manifests at `:latest`. Comparing the manifests against the Porch release blueprints:

| Porch release | Matches these manifests? |
|---|---|
| `:latest` (post-v1.5.9) | No - dropped `--config` / `--repo-sync-frequency`, new FunctionConfig-CRD architecture needing extra RBAC |
| v1.5.8 / v1.5.9 | No - changed the function-runner config format |
| v1.5.7 | Yes - identical command, paths (`/home/nonroot/server`, `--config`, health-probe) and args |

The manifests are the v1.5.7 release blueprint, so this pins all four images (`porch-server`, `porch-function-runner`, `porch-controllers`, `porch-wrapper-server`) from `:latest` to `v1.5.7`.

### Verified

- Structural: the v1.5.7 blueprint function-runner command is byte-identical to these manifests.
- `porch-server:v1.5.7 --help` accepts `--repo-sync-frequency` (the flag `:latest` rejects).
- On a fresh R6 sandbox, deploying Porch from a pinned release (instead of `:latest`) brings all Porch pods to Ready and lets the install complete - confirming the `:latest` drift is the root cause and pinning is the fix.

Companion to #143 (both are `:latest` / registry drift breaking fresh installs).
