### PR TITLE
Issue 593: Move test-infra testing yaml resources to catalog repository

### DIFF
--- a/test-infra-resources/argocd/002-free5gc-cp.yaml
+++ b/test-infra-resources/argocd/002-free5gc-cp.yaml
@@ -1,0 +1,23 @@
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2025 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: free5gc-control-plane
+spec:
+  upstream:
+    repo: catalog-workloads-free5gc
+    package: free5gc-cp
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: regional
+    package: free5gc-cp
+  annotations:
+    approval.nephio.org/policy: initial

--- a/test-infra-resources/flux/002-free5gc-cp.yaml
+++ b/test-infra-resources/flux/002-free5gc-cp.yaml
@@ -1,0 +1,26 @@
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2025 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: free5gc-control-plane
+spec:
+  upstream:
+    repo: catalog-workloads-free5gc
+    package: free5gc-cp
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: regional
+    package: free5gc-cp
+  annotations:
+    approval.nephio.org/policy: initial
+  pipeline:
+    mutators:
+    - image: docker.io/nephio/gen-kustomize-res:latest

--- a/test-infra-resources/free5gc/002-edge-clusters.yaml
+++ b/test-infra-resources/free5gc/002-edge-clusters.yaml
@@ -1,0 +1,34 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: edge-clusters
+spec:
+  upstream:
+    repo: catalog-infra-capi
+    package: nephio-workload-cluster
+    workspaceName: ${BRANCH}
+  targets:
+  - repositories:
+    - name: mgmt
+      packageNames:
+      - edge01
+      - edge02
+    template:
+      annotations:
+        approval.nephio.org/policy: initial
+      pipeline:
+        mutators:
+        - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2
+          configMap:
+            nephio.org/site-type: edge
+            nephio.org/region: us-west1

--- a/test-infra-resources/free5gc/002-network.yaml
+++ b/test-infra-resources/free5gc/002-network.yaml
@@ -1,0 +1,24 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: network
+spec:
+  upstream:
+    repo: catalog-distros-sandbox
+    package: network
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: mgmt
+    package: network
+  annotations:
+    approval.nephio.org/policy: initial

--- a/test-infra-resources/free5gc/002-secret.yaml
+++ b/test-infra-resources/free5gc/002-secret.yaml
@@ -1,0 +1,19 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: srl.nokia.com
+  namespace: default
+type: kubernetes.io/basic-auth
+stringData:
+  username: admin
+  password: NokiaSrl1!

--- a/test-infra-resources/free5gc/004-free5gc-operator.yaml
+++ b/test-infra-resources/free5gc/004-free5gc-operator.yaml
@@ -1,0 +1,16 @@
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: free5gc-operator
+spec:
+  upstream:
+    repo: catalog-workloads-free5gc
+    package: free5gc-operator
+    workspaceName: ${BRANCH}
+  targets:
+  - objectSelector:
+      apiVersion: infra.nephio.org/v1alpha1
+      kind: WorkloadCluster
+    template:
+      annotations:
+        approval.nephio.org/policy: initial

--- a/test-infra-resources/free5gc/005-edge-free5gc-upf.yaml
+++ b/test-infra-resources/free5gc/005-edge-free5gc-upf.yaml
@@ -1,0 +1,22 @@
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: edge-free5gc-upf
+spec:
+  upstream:
+    repo: catalog-workloads-free5gc
+    package: pkg-example-upf-bp
+    workspaceName: ${BRANCH}
+  targets:
+  - objectSelector:
+      apiVersion: infra.nephio.org/v1alpha1
+      kind: WorkloadCluster
+      matchLabels:
+        nephio.org/site-type: edge
+    template:
+      downstream:
+        package: free5gc-upf
+      annotations:
+        approval.nephio.org/policy: always
+      injectors:
+      - nameExpr: target.name

--- a/test-infra-resources/free5gc/006-regional-free5gc-amf.yaml
+++ b/test-infra-resources/free5gc/006-regional-free5gc-amf.yaml
@@ -1,0 +1,22 @@
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: regional-free5gc-amf
+spec:
+  upstream:
+    repo: catalog-workloads-free5gc
+    package: pkg-example-amf-bp
+    workspaceName: ${BRANCH}
+  targets:
+  - objectSelector:
+      apiVersion: infra.nephio.org/v1alpha1
+      kind: WorkloadCluster
+      matchLabels:
+        nephio.org/site-type: regional
+    template:
+      downstream:
+        package: free5gc-amf
+      annotations:
+        approval.nephio.org/policy: always
+      injectors:
+      - nameExpr: target.name

--- a/test-infra-resources/free5gc/006-regional-free5gc-smf.yaml
+++ b/test-infra-resources/free5gc/006-regional-free5gc-smf.yaml
@@ -1,0 +1,22 @@
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: regional-free5gc-smf
+spec:
+  upstream:
+    repo: catalog-workloads-free5gc
+    package: pkg-example-smf-bp
+    workspaceName: ${BRANCH}
+  targets:
+  - objectSelector:
+      apiVersion: infra.nephio.org/v1alpha1
+      kind: WorkloadCluster
+      matchLabels:
+        nephio.org/site-type: regional
+    template:
+      downstream:
+        package: free5gc-smf
+      annotations:
+        approval.nephio.org/policy: always
+      injectors:
+      - nameExpr: target.name

--- a/test-infra-resources/free5gc/007-edge01-ueransim.yaml
+++ b/test-infra-resources/free5gc/007-edge01-ueransim.yaml
@@ -1,0 +1,16 @@
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: edge01-ueransim
+spec:
+  upstream:
+    repo: catalog-workloads-tools
+    package: ueransim
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: edge01
+    package: ueransim
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: edge01

--- a/test-infra-resources/oai/001-infra.yaml
+++ b/test-infra-resources/oai/001-infra.yaml
@@ -1,0 +1,78 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-core-clusters-mgmt-core
+spec:
+  upstream:
+    repo: catalog-infra-capi
+    package: nephio-workload-cluster
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: mgmt
+    package: core
+  annotations:
+    approval.nephio.org/policy: initial
+  pipeline:
+    mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2
+      configMap:
+        nephio.org/site-type: core
+        nephio.org/region: us-west1
+---
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: oai-regional-clusters
+spec:
+  upstream:
+    repo: catalog-infra-capi
+    package: nephio-workload-cluster
+    workspaceName: ${BRANCH}
+  targets:
+  - repositories:
+    - name: mgmt
+      packageNames:
+        - regional
+    template:
+      annotations:
+        approval.nephio.org/policy: initial
+      pipeline:
+        mutators:
+        - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2
+          configMap:
+            nephio.org/site-type: regional
+            nephio.org/region: us-west1
+---
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: oai-edge-clusters
+spec:
+  upstream:
+    repo: catalog-infra-capi
+    package: nephio-workload-cluster
+    workspaceName: ${BRANCH}
+  targets:
+  - repositories:
+    - name: mgmt
+      packageNames:
+        - edge
+    template:
+      annotations:
+        approval.nephio.org/policy: initial
+      pipeline:
+        mutators:
+        - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2
+          configMap:
+            nephio.org/site-type: edge
+            nephio.org/region: us-west1

--- a/test-infra-resources/oai/001-network.yaml
+++ b/test-infra-resources/oai/001-network.yaml
@@ -1,0 +1,24 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: network
+spec:
+  upstream:
+    repo: catalog-distros-sandbox
+    package: network
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: mgmt
+    package: network
+  annotations:
+    approval.nephio.org/policy: initial

--- a/test-infra-resources/oai/001-secret.yaml
+++ b/test-infra-resources/oai/001-secret.yaml
@@ -1,0 +1,19 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: srl.nokia.com
+  namespace: default
+type: kubernetes.io/basic-auth
+stringData:
+  username: admin
+  password: NokiaSrl1!

--- a/test-infra-resources/oai/002-database.yaml
+++ b/test-infra-resources/oai/002-database.yaml
@@ -1,0 +1,32 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha2
+kind: PackageVariantSet
+metadata:
+  name: oai-common
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: database
+    workspaceName: ${BRANCH}
+  targets:
+  - objectSelector:
+      apiVersion: infra.nephio.org/v1alpha1
+      kind: WorkloadCluster
+      matchLabels:
+        nephio.org/site-type: core
+    template:
+      downstream:
+        package: database
+      annotations:
+        approval.nephio.org/policy: initial
+      injectors:
+      - nameExpr: target.name

--- a/test-infra-resources/oai/002-operators.yaml
+++ b/test-infra-resources/oai/002-operators.yaml
@@ -1,0 +1,79 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-cp-operators
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-cp-operators
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: core
+    package: oai-cp-operators
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: core
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-up-operators
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-up-operators
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: edge
+    package: oai-up-operators
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: edge
+
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-ran-operator-edge
+spec:
+  upstream:
+    repo: catalog-workloads-oai-ran
+    package: oai-ran-operator
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: edge
+    package: oai-ran-operator
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: edge
+
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-ran-operator-regional
+spec:
+  upstream:
+    repo: catalog-workloads-oai-ran
+    package: oai-ran-operator
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: regional
+    package: oai-ran-operator
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: regional

--- a/test-infra-resources/oai/003-core-network.yaml
+++ b/test-infra-resources/oai/003-core-network.yaml
@@ -1,0 +1,128 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2023 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-nrf
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-nrf
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: core
+    package: oai-nrf
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: core
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-udm
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-udm
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: core
+    package: oai-udm
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: core
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-ausf
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-ausf
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: core
+    package: oai-ausf
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: core
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-udr
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-udr
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: core
+    package: oai-udr
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: core
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-amf
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-amf
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: core
+    package: oai-amf
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: core
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-smf
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-smf
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: core
+    package: oai-smf
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: core
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-upf-edge
+spec:
+  upstream:
+    repo: oai-core-packages
+    package: oai-upf-edge
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: edge
+    package: oai-upf
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: edge

--- a/test-infra-resources/oai/004a-ran-network.yaml
+++ b/test-infra-resources/oai/004a-ran-network.yaml
@@ -1,0 +1,26 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2024 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-cucp
+spec:
+  upstream:
+    repo: catalog-workloads-oai-ran
+    package: pkg-example-cucp-bp
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: regional
+    package: oai-ran-cucp
+  annotations:
+    approval.nephio.org/policy: always
+  injectors:
+  - name: regional

--- a/test-infra-resources/oai/004b-ran-network.yaml
+++ b/test-infra-resources/oai/004b-ran-network.yaml
@@ -1,0 +1,44 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2024 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-du
+spec:
+  upstream:
+    repo: catalog-workloads-oai-ran
+    package: pkg-example-du-bp
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: edge
+    package: oai-ran-du
+  annotations:
+    approval.nephio.org/policy: always
+  injectors:
+  - name: edge
+---
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-cuup
+spec:
+  upstream:
+    repo: catalog-workloads-oai-ran
+    package: pkg-example-cuup-bp
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: edge
+    package: oai-ran-cuup
+  annotations:
+    approval.nephio.org/policy: always
+  injectors:
+  - name: edge
+

--- a/test-infra-resources/oai/005-ue.yaml
+++ b/test-infra-resources/oai/005-ue.yaml
@@ -1,0 +1,26 @@
+---
+# SPDX-license-identifier: Apache-2.0
+##############################################################################
+# Copyright (c) 2024 The Nephio Authors.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Apache License, Version 2.0
+# which accompanies this distribution, and is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+##############################################################################
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: oai-ue
+spec:
+  upstream:
+    repo: catalog-workloads-oai-ran
+    package: pkg-example-ue-bp
+    workspaceName: ${BRANCH}
+  downstream:
+    repo: edge
+    package: oai-ran-ue
+  annotations:
+    approval.nephio.org/policy: initial
+  injectors:
+  - name: edge

--- a/test-infra-resources/ocloud/001-focom-provisioning-request.yaml
+++ b/test-infra-resources/ocloud/001-focom-provisioning-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: focom.nephio.org/v1alpha1
+kind: OCloud
+metadata:
+  name: ocloud-1
+  namespace: focom-operator-system
+spec:
+  o2imsSecret:
+    secretRef:
+      name: ocloud-kubeconfig
+      namespace: default
+---
+apiVersion: provisioning.oran.org/v1alpha1
+kind: TemplateInfo
+metadata:
+  name: nephio-workload-cluster-${BRANCH}
+  namespace: focom-operator-system
+spec:
+  templateName: nephio-workload-cluster
+  templateVersion: ${BRANCH}
+  templateParameterSchema: |
+    {
+      "type": "object",
+      "infra": {
+      "param1": {
+          "type": "string"
+        },
+        "params": {
+          "type": "integer"
+        }
+      },
+      "required": ["param1"]
+    }
+---
+
+apiVersion: focom.nephio.org/v1alpha1
+kind: FocomProvisioningRequest
+metadata:
+  name: focom-cluster-prov-req-nephio
+  namespace: focom-operator-system
+spec:
+  name: edge-cluster-req
+  description: "Provisioning request for setting up a sample edge kind cluster"
+  oCloudId: ocloud-1
+  oCloudNamespace: focom-operator-system
+  templateName: nephio-workload-cluster
+  templateVersion: ${BRANCH}
+  templateParameters:
+    clusterName: edge
+    labels:
+      nephio.org/site-type: edge
+      nephio.org/region: europe-paris-west
+      nephio.org/owner: nephio-o2ims


### PR DESCRIPTION
Hi Nephio team,

I have fixed [issue #593](https://github.com/nephio-project/nephio/issues/593). This PR moves `test-infra` resources to the catalog under the `catalog/test-infra-resoures` path.
Compared to the issue description, I also created some other YAML definition files in the `test_infra` project, which I migrated to the catalog.

Please don’t hesitate to provide feedback if the PR needs more work.

P.S: Related PRs: [[test_infra](https://github.com/nephio-project/test-infra/pull/379)], [[docs](https://github.com/nephio-project/docs/pull/307)]