### PR TITLE
[blocked on nephio#1170] Stop pinning the o2ims operator's Kubernetes API address

### DIFF
--- a/nephio/optional/o2ims/app/deployment.yaml
+++ b/nephio/optional/o2ims/app/deployment.yaml
@@ -28,8 +28,6 @@ spec:
         env:
         - name: 'UPSTREAM_PKG_REPO'
           value: 'catalog-infra-capi'
-        - name: 'KUBERNETES_BASE_URL'
-          value: 'https://kubernetes.default.svc'
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
> **Do not merge before nephio-project/nephio#1170 is in a published image, and pin that image here.** Until then the operator's own default for `KUBERNETES_BASE_URL` is `http://127.0.0.1:8080`, and dropping the variable here would point every deployment made from this package at a `kubectl proxy` that does not exist inside the pod. #1169 was closed in favour of #1170, which carries both the TLS and the token fix. The title carries the blocker; happy to move it back to draft if you would rather the state enforce it.

`nephio/optional/o2ims/app/deployment.yaml` pins the API server address:

```yaml
        - name: 'KUBERNETES_BASE_URL'
          value: 'https://kubernetes.default.svc'
```

Quoting the Kubernetes documentation on [accessing the API from a Pod](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/):

> Kubernetes does not guarantee that the API server has a valid certificate for the hostname `kubernetes.default.svc`; however, the control plane **is** expected to present a valid certificate for the hostname or IP address that `$KUBERNETES_SERVICE_HOST` represents.

That distinction did not matter while the operator skipped certificate verification, which is the defect nephio-project/nephio#1169 fixes. Once it verifies, the pinned name is the one address whose certificate a cluster is free not to carry, and the operator already derives the advertised one for itself. Removing the pin is all that is left to do here.

In practice `kubeadm` and `kind` both put `kubernetes.default.svc` in the serving certificate's SANs, so this is not expected to change behaviour on a typical cluster. It removes the reliance, rather than fixing a breakage.

### Sequencing

The manifest and the image version independently, and this package uses `image: docker.io/nephio/o2ims-operator:latest` with `imagePullPolicy: IfNotPresent`, so a node holding an older `latest` would still be running the old code after this merges. The safe order is: nephio-project/nephio#1170 merges, the postsubmit publishes an image containing it, that image's `${BUILD_ID}` tag or digest is pinned in this file, then this merges. Pinning matters as much as ordering: with `latest` and `IfNotPresent`, a node holding an older cached `latest` keeps running the old binary even after a rollout.

If you would rather not sequence two repositories, an alternative is to keep the variable and set it to `https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)`, which the kubelet expands from the service environment and which works against both the old and the new operator code. I have not tested that expansion against a live cluster, so I have not proposed it as the change — say the word and I will verify it and switch.

### Context

Part of a small series on the operators' Kubernetes clients:

- nephio-project/nephio#1168 — FOCOM verifies API certificates by default
- nephio-project/nephio#1169 — o2ims verifies API certificates by default (this PR's companion)
- nephio-project/nephio#1170 — o2ims reads its service account token without a shell

The `nephio/optional/focom-operator` package here needs nothing: its bundle carries no `env` block at all, so neither `PORCH_HTTPS_VERIFY` nor `KUBERNETES_BASE_URL` is set from this repository.
