### PR TITLE
GitHub support for infra repo

### DIFF
--- a/distros/sandbox/repository/README.md
+++ b/distros/sandbox/repository/README.md
@@ -2,5 +2,58 @@
 
 ## Description
 
-Provisions a Gitea repo for a Nephio cluster
-The repo will be named after the cluster name
+Provisions a Git repository for a Nephio cluster. Supports multiple git providers:
+- **Gitea** (default) - Self-hosted git server
+- **GitHub** - GitHub.com or GitHub Enterprise
+- **GitLab** - GitLab.com or self-hosted GitLab
+
+The repository will be named after the cluster name.
+
+## Configuration
+
+Configure the git provider in `git-context.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: git-context
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    kpt.dev/config-injection: "required"
+data:
+  provider: gitea      # Options: gitea, github, gitlab
+  url: "http://172.18.0.200:3000"  # Required for Gitea, optional for custom GitHub/GitLab URLs
+  org: nephio  # Organization/owner name for the repository
+```
+
+### Provider-Specific Configuration
+
+#### Gitea (Default)
+```yaml
+provider: gitea
+url: "http://172.18.0.200:3000"
+org: nephio
+```
+Generates: `http://172.18.0.200:3000/nephio/{cluster-name}.git`
+
+#### GitHub
+```yaml
+provider: github
+org: your-org-name
+```
+Generates: `https://github.com/your-org-name/{cluster-name}.git`
+
+#### GitLab
+```yaml
+provider: gitlab
+org: your-org-or-group
+```
+Generates: `https://gitlab.com/your-org-or-group/{cluster-name}.git`
+
+For self-hosted GitHub/GitLab, specify `url`:
+```yaml
+provider: gitlab
+url: "https://gitlab.mycompany.com"
+org: myteam
+```

--- a/distros/sandbox/repository/git-context.yaml
+++ b/distros/sandbox/repository/git-context.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: git-context
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    kpt.dev/config-injection: "required"
+data:
+  provider: example
+  org: example
+  url: "http://172.18.0.200:3000"

--- a/distros/sandbox/repository/set-values.yaml
+++ b/distros/sandbox/repository/set-values.yaml
@@ -8,28 +8,70 @@ metadata: # kpt-merge: /generate-values
 source: |-
   load("krmfn.star", "krmfn")
   def set_values(resources):
+    # Default values
+    clusterName = "example-cluster-name"
+    provider = "gitea"
+    url = "http://172.18.0.200:3000"
+    org = "nephio"
+    
     # this package can be cloned manually and used without injection; in that case base
     # the repository name on the package name
     for r in resources:
       if krmfn.match_gvk(r, "v1", "ConfigMap") and krmfn.match_name(r, "kptfile.kpt.dev"):
-        clusterName = r["data"]["name"]
-    # if a WorkloadCluster exists, and was injected, then use that for the name
+        clusterName = r["data"]["name"]  
+    # Read from ConfigMap (git-context.yaml)
+    for r in resources:
+      if krmfn.match_gvk(r, "v1", "ConfigMap") and krmfn.match_name(r, "git-context"):
+        data = r.get("data", {})
+        print("DEBUG: Active Config -> data: {}".format(data))
+        provider = data.get("provider",provider)
+        org = data.get("org",org)
+        url = data.get("url",url)
+        
+    
+    # Read from WorkloadCluster for cluster name
     for r in resources:
       if krmfn.match_gvk(r, "infra.nephio.org/v1alpha1", "WorkloadCluster") and "annotations" in r["metadata"] and "kpt.dev/injected-resource" in r["metadata"]["annotations"]:
         clusterName = r["spec"]["clusterName"]
+    
+    # Build git repository URL based on provider
+    gitRepoUrl = ""
+    if provider == "gitea":
+      gitRepoUrl = url + "/" + org + "/" + clusterName + ".git"
+    elif provider == "github":
+      gitRepoUrl = "https://github.com/" + org + "/" + clusterName + ".git"
+    elif provider == "gitlab":
+      gitRepoUrl = "https://gitlab.com/" + org + "/" + clusterName + ".git"
+    
     for r in resources:
       if krmfn.match_gvk(r, "infra.nephio.org/v1alpha1", "Repository"):
         r["metadata"]["name"] = clusterName
         r["spec"]["description"] = clusterName + " repository"
+        r["spec"]["provider"] = provider
+        if provider != "gitea":
+          r["spec"]["org"] = org
+        # Set git provider annotation for reference
+        if "annotations" not in r["metadata"]:
+          r["metadata"]["annotations"] = {}
+        r["metadata"]["annotations"]["nephio.org/git-provider"] = provider
+      
       if krmfn.match_gvk(r, "config.porch.kpt.dev/v1alpha1", "Repository"):
         r["metadata"]["name"] = clusterName
-        r["spec"]["git"]["repo"] = "http://172.18.0.200:3000/nephio/" + clusterName + ".git"
+        r["spec"]["git"]["repo"] = gitRepoUrl
         r["spec"]["git"]["secretRef"]["name"] = clusterName + "-access-token-porch"
         if clusterName == "mgmt-staging":
            r["spec"]["deployment"] = False
+           if "annotations" not in r["metadata"]:
+             r["metadata"]["annotations"] = {}
            r["metadata"]["annotations"]["nephio.org/staging"] = "true"
+      
       if krmfn.match_gvk(r, "infra.nephio.org/v1alpha1", "Token"):
         r["metadata"]["name"] = clusterName + "-access-token-porch"
+        # Set git provider and org annotations for Token
+        if "annotations" not in r["metadata"]:
+          r["metadata"]["annotations"] = {}
+        r["metadata"]["annotations"]["nephio.org/git-provider"] = provider
+        r["metadata"]["annotations"]["nephio.org/git-org"] = org
         if "annotations" in r["metadata"] and "nephio.org/gitops" in r["metadata"]["annotations"] and "configsync" in r["metadata"]["annotations"]["nephio.org/gitops"]:
           r["metadata"]["name"] = clusterName + "-access-token-configsync"
           if clusterName == "mgmt" or clusterName == "mgmt-staging":

--- a/infra/capi/nephio-workload-cluster/pv-repo.yaml
+++ b/infra/capi/nephio-workload-cluster/pv-repo.yaml
@@ -15,6 +15,10 @@ spec:
   injectors:
   - kind: WorkloadCluster
     name: example
+  - group: ""
+    version: v1
+    kind: ConfigMap
+    name: git-context
   pipeline:
     mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4


### PR DESCRIPTION
# Add git provider configuration to sandbox repository package

## Summary

The `distros/sandbox/repository` package currently hardcodes a Gitea endpoint
when generating repository resources. This makes the provider, host and
organization configurable, so the sandbox can provision cluster repositories on
GitHub or GitLab as well as Gitea.

This is the packaging half of GitHub provider support; the API and controller
changes are companion PRs against `nephio-project/api` and
`nephio-project/nephio`.

## Changes

### New `git-context` ConfigMap

Adds `distros/sandbox/repository/git-context.yaml`, a kpt config-injection
point (`kpt.dev/config-injection: "required"`) carrying three keys:

| Key        | Description | Default |
|------------|-------------|---------|
| `provider` | `gitea`, `github`, or `gitlab` | `gitea` |
| `url`      | Base URL of the git server | `http://172.18.0.200:3000` |
| `org`      | Organization / owner for the repository | `nephio` |

### `set-values.yaml`

- Reads the `git-context` ConfigMap, falling back to the previous hardcoded
  values when it is absent, so the package still works when cloned manually.
- Builds the Porch `Repository` git URL from the provider rather than the
  fixed Gitea address.
- Sets `spec.provider` on the `infra.nephio.org` `Repository`, and `spec.org`
  for non-Gitea providers.
- Annotates `Repository` and `Token` with `nephio.org/git-provider`, and
  `Token` additionally with `nephio.org/git-org`.
- Guards annotation writes with an existence check before assignment; the
  previous `mgmt-staging` branch assumed `metadata.annotations` was always
  present.

### `pv-repo.yaml`

Registers the `git-context` ConfigMap as a second injector alongside the
existing `WorkloadCluster` injector.

### README

Documents the provider options and the URL each one generates.

## Backward compatibility

Behaviour is unchanged for existing users. Every value falls back to the
previous hardcoded default, so a package rendered without a `git-context`
override produces the same Gitea URL and resources as before. No existing field
was removed or renamed.

## Dependencies

`spec.provider` and `spec.org` on the `infra.nephio.org` `Repository` require
the companion API change:

- nephio-project/api — "Add provider, url, and org fields to Repository CRD"

Rendering this package against an older API module will produce a `Repository`
with fields the CRD rejects.

## Testing

Rendered the package for each provider and confirmed the generated Porch
`Repository` URL, `spec.provider`/`spec.org`, and the provider annotations.
